### PR TITLE
Add persistent chain storage and API utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ datos_importantes.txt
 data/
 node_modules/
 .test.js
+storage/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ datasets or model checkpoints while tokens can be used to incentivise agents.
 
 2. Open `http://localhost:8000` in your browser to access the web interface.
 
+Chain data is automatically saved to disk so blocks remain after you restart the server.
+
 Multiple nodes can be launched using the extra `start:*` scripts in
 `package.json`.
 
@@ -39,12 +41,23 @@ Use `POST /api/ai/store` to record metadata about models or datasets on chain.
 Each block will contain fields `model`, `description` and `hash` so you can
 track AI assets over time.
 
+### API Endpoints
+
+The REST API exposes several helpers for querying the chain:
+
+- `GET /api/validators` – list validator stakes
+- `GET /api/verify` – check whether the chain is valid
+- `GET /api/block/:hash` – fetch a block by its hash
+- `GET /api/balance/:address` – show the balance of a wallet address
+
 ### For Developers
 
 - Node.js 18 or later is recommended.
 - REST API endpoints are defined in `src/middleware/Api/Endpoints`.
 - Frontend files live in `src/public` and use Tailwind CSS via CDN.
 - The blockchain core can be found under `src/blockchain`.
+- Chain data is saved to `src/storage/chain.json` so your history persists across restarts.
+- Helper methods now let you verify the chain, query balances and inspect validator stakes.
 
 ### For Non‑Programmers and Investors
 

--- a/src/blockchain/blockchain.js
+++ b/src/blockchain/blockchain.js
@@ -1,11 +1,17 @@
 import Block from './block.js';
 import validator from './modules/validator.js';
 import MemoryPool from './memPool.js';
+import { loadBlocks, saveBlocks } from './modules/storage.js';
 
 class Blockchain {
 
         constructor(){
-                this.blocks = [Block.genesis];
+                const stored = loadBlocks();
+                if(stored && Array.isArray(stored) && stored.length > 0){
+                        this.blocks = stored.map((b) => new Block(b.timestamp, b.previousHash, b.data, b.hash, b.validator));
+                } else {
+                        this.blocks = [Block.genesis];
+                }
                 this.memoryPool = new MemoryPool();
                 this.validators = {};
         }
@@ -22,11 +28,12 @@ class Blockchain {
                 const previousBlock = this.blocks[this.blocks.length - 1];
                 const block = Block.mine(previousBlock, data, validatorKey);
                 this.blocks.push(block);
+                saveBlocks(this.blocks);
 
                 return block;
         }
 
-	replace(newBlocks = []){
+        replace(newBlocks = []){
 		
 		if(newBlocks.length < this.blocks.length){
 			throw Error('La cadena no es mas larga que la actual');
@@ -38,11 +45,52 @@ class Blockchain {
 			throw Error('La cadena es invalida');
 		}
 
-		this.blocks = newBlocks;
+                this.blocks = newBlocks;
+                saveBlocks(this.blocks);
 
-		return this.blocks;
+                return this.blocks;
 
-	}
+        }
+
+        getLatestBlock(){
+                return this.blocks[this.blocks.length - 1];
+        }
+
+        verifyChain(chain = this.blocks){
+                try {
+                        validator(chain);
+                        return true;
+                } catch(err){
+                        return false;
+                }
+        }
+
+        findBlockByHash(hash){
+                return this.blocks.find((block) => block.hash === hash);
+        }
+
+        getBalance(address){
+                let balance = 0;
+                this.blocks.forEach(({data = []}) => {
+                        if(Array.isArray(data)){
+                                data.forEach(({input, outputs}) => {
+                                        outputs.forEach(({address: addr, amount}) => {
+                                                if(addr === address) balance += Number(amount);
+                                        });
+                                        if(input.address === address) balance -= Number(input.amount);
+                                });
+                        }
+                });
+                return balance;
+        }
+
+        getStakeOf(validatorKey){
+                return this.validators[validatorKey] || 0;
+        }
+
+        getValidators(){
+                return { ...this.validators };
+        }
 
 }
 

--- a/src/blockchain/modules/storage.js
+++ b/src/blockchain/modules/storage.js
@@ -1,0 +1,27 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = path.join(__dirname, '../../storage');
+const DATA_FILE = path.join(DATA_DIR, 'chain.json');
+
+export function loadBlocks() {
+  if (!existsSync(DATA_FILE)) return null;
+  try {
+    const data = JSON.parse(readFileSync(DATA_FILE));
+    return data;
+  } catch (err) {
+    console.error('Failed to load blockchain data:', err);
+    return null;
+  }
+}
+
+export function saveBlocks(blocks) {
+  try {
+    if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
+    writeFileSync(DATA_FILE, JSON.stringify(blocks, null, 2));
+  } catch (err) {
+    console.error('Failed to save blockchain data:', err);
+  }
+}

--- a/src/middleware/Api/Endpoints/balance.js
+++ b/src/middleware/Api/Endpoints/balance.js
@@ -1,0 +1,5 @@
+export default (req, res) => {
+    const { address } = req.params;
+    const balance = newBlockchain.getBalance(address);
+    res.json({ address, balance });
+};

--- a/src/middleware/Api/Endpoints/block_get.js
+++ b/src/middleware/Api/Endpoints/block_get.js
@@ -1,0 +1,9 @@
+export default (req, res) => {
+    const { hash } = req.params;
+    const block = newBlockchain.findBlockByHash(hash);
+    if(block) {
+        res.json(block);
+    } else {
+        res.status(404).json({ error: 'Block not found' });
+    }
+};

--- a/src/middleware/Api/Endpoints/index.js
+++ b/src/middleware/Api/Endpoints/index.js
@@ -8,6 +8,10 @@ import walletStake from './wallet_stake.js';
 import mine from './mine.js';
 import transactionsNew from './transactions_new.js';
 import aiStore from './ai_store.js';
+import validators from './validators.js';
+import verify from './verify.js';
+import blockGet from './block_get.js';
+import balance from './balance.js';
 
 const r = express.Router();
 
@@ -23,6 +27,18 @@ r.route('/transactions')
 
 r.route('/mine/transactions')
 .get(mineTransactions);
+
+r.route('/validators')
+.get(validators);
+
+r.route('/verify')
+.get(verify);
+
+r.route('/block/:hash')
+.get(blockGet);
+
+r.route('/balance/:address')
+.get(balance);
 
 
 /**

--- a/src/middleware/Api/Endpoints/validators.js
+++ b/src/middleware/Api/Endpoints/validators.js
@@ -1,0 +1,3 @@
+export default (req, res) => {
+    res.json(newBlockchain.getValidators());
+};

--- a/src/middleware/Api/Endpoints/verify.js
+++ b/src/middleware/Api/Endpoints/verify.js
@@ -1,0 +1,4 @@
+export default (req, res) => {
+    const valid = newBlockchain.verifyChain();
+    res.json({ valid });
+};


### PR DESCRIPTION
## Summary
- save blocks to `src/storage/chain.json` via storage helpers
- extend `Blockchain` with chain verification and balance utilities
- expose endpoints for validators, chain validity, block lookup and balances
- document REST API endpoints in the README

## Testing
- `npm run eslint` *(fails: ESLint config missing)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855c492f8988329a76127696e51e3a4
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added persistent chain storage and new API endpoints for chain verification, block lookup, validator info, and wallet balances.

- **New Features**
  - Blocks are saved to disk and loaded on startup.
  - Added endpoints for validators, chain validity, block lookup by hash, and wallet balances.
  - Updated README with new API details.

<!-- End of auto-generated description by cubic. -->

