### PR TITLE
Add AI blocks listing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ validator proportionally to their stake.
 
 Use `POST /api/ai/store` to record metadata about models or datasets on chain.
 Each block will contain fields `model`, `description` and `hash` so you can
-track AI assets over time.
+track AI assets over time. List all recorded AI blocks via
+`GET /api/ai/list`.
 
 ### API Endpoints
 
@@ -50,6 +51,7 @@ The REST API exposes several helpers for querying the chain:
 - `GET /api/verify` – check whether the chain is valid
 - `GET /api/block/:hash` – fetch a block by its hash
 - `GET /api/balance/:address` – show the balance of a wallet address
+- `GET /api/ai/list` – list all blocks that contain AI data
 
 ### Blockchain Utilities
 

--- a/src/middleware/Api/Endpoints/ai_list.js
+++ b/src/middleware/Api/Endpoints/ai_list.js
@@ -1,0 +1,7 @@
+export default (req, res) => {
+    const aiBlocks = newBlockchain.blocks.filter(
+        ({ data }) => data && data.type === 'AI_DATA'
+    );
+    res.json(aiBlocks);
+};
+

--- a/src/middleware/Api/Endpoints/index.js
+++ b/src/middleware/Api/Endpoints/index.js
@@ -8,6 +8,7 @@ import walletStake from './wallet_stake.js';
 import mine from './mine.js';
 import transactionsNew from './transactions_new.js';
 import aiStore from './ai_store.js';
+import aiList from './ai_list.js';
 import mempool from './mempool.js';
 import validators from './validators.js';
 import verify from './verify.js';
@@ -43,6 +44,9 @@ r.route('/block/:hash')
 
 r.route('/balance/:address')
 .get(balance);
+
+r.route('/ai/list')
+.get(aiList);
 
 
 /**


### PR DESCRIPTION
## Summary
- add endpoint handler for listing AI data blocks
- register `GET /ai/list` route
- document the new route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855db65b6848329be0add8420237713
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new API endpoint to list all AI data blocks with GET /api/ai/list.

- **New Features**
 - Added handler for listing AI data blocks.
 - Registered the new route and updated documentation.

<!-- End of auto-generated description by cubic. -->

