### PR TITLE
Add block signatures and validation checks

### DIFF
--- a/__tests__/block_signature.test.js
+++ b/__tests__/block_signature.test.js
@@ -1,0 +1,22 @@
+import Blockchain from '../src/blockchain/index.js';
+import Wallet from '../src/wallet/index.js';
+import { elliptic } from '../src/modules/index.js';
+
+describe('Block signature', () => {
+    test('mined block has a valid signature', () => {
+        const bc = new Blockchain();
+        const wallet = new Wallet(bc, 0);
+        const block = bc.addBlock('data', wallet);
+        expect(block.signature).toBeDefined();
+        const valid = elliptic.verifySignature(block.validator, block.signature, block.hash);
+        expect(valid).toBe(true);
+    });
+
+    test('chain validation fails with wrong signature', () => {
+        const bc = new Blockchain();
+        const wallet = new Wallet(bc, 0);
+        const block = bc.addBlock('data', wallet);
+        block.signature = '00';
+        expect(bc.verifyChain()).toBe(false);
+    });
+});

--- a/src/blockchain/block.js
+++ b/src/blockchain/block.js
@@ -1,24 +1,42 @@
 import { gnHash } from '../modules/index.js';
 
-class Block{
-        constructor(timestamp, previousHash, data, hash, validator){
+class Block {
+        constructor(timestamp, previousHash, data, hash, validator, signature) {
                 this.timestamp = timestamp;
                 this.previousHash = previousHash;
                 this.data = data;
                 this.hash = hash;
                 this.validator = validator;
+                this.signature = signature;
         }
 
-        static get genesis(){
+        static get genesis() {
                 const timestamp = (new Date(2020, 1, 1)).getTime();
-                return new this(timestamp, undefined, 'S-U-N-I', 'hash-genesis', 'genesis');
+                return new this(
+                        timestamp,
+                        undefined,
+                        'S-U-N-I',
+                        'hash-genesis',
+                        'genesis',
+                        'genesis'
+                );
         }
 
-        static mine(previousBlock, data, validator){
+        static mine(previousBlock, data, validatorWallet) {
                 const { hash: previousHash } = previousBlock;
                 const timestamp = Date.now();
+                const validator =
+                        typeof validatorWallet === 'string'
+                                ? validatorWallet
+                                : validatorWallet.publicKey;
                 const hash = Block.hash(timestamp, previousHash, data, validator);
-                return new this(timestamp, previousHash, data, hash, validator);
+                let signature;
+                if (validatorWallet && typeof validatorWallet.sign === 'function') {
+                        const sig = validatorWallet.sign(hash);
+                        // store as hex string for serialization
+                        signature = typeof sig.toDER === 'function' ? sig.toDER('hex') : sig;
+                }
+                return new this(timestamp, previousHash, data, hash, validator, signature);
         }
 
         static hash(timestamp, previousHash, data, validator){
@@ -32,7 +50,8 @@ class Block{
                         previousHash,
                         data,
                         hash,
-                        validator
+                        validator,
+                        signature
                 } = this;
 
 		return ` BLOCK
@@ -41,6 +60,7 @@ class Block{
 		Data: ${data}
                 Hash: ${hash}
                 Validator: ${validator}
+                Signature: ${signature}
                 `;
         }
 

--- a/src/blockchain/blockchain.js
+++ b/src/blockchain/blockchain.js
@@ -8,7 +8,16 @@ class Blockchain {
         constructor(){
                 const stored = loadBlocks();
                 if(stored && Array.isArray(stored) && stored.length > 0){
-                        this.blocks = stored.map((b) => new Block(b.timestamp, b.previousHash, b.data, b.hash, b.validator));
+                        this.blocks = stored.map((b) =>
+                                new Block(
+                                        b.timestamp,
+                                        b.previousHash,
+                                        b.data,
+                                        b.hash,
+                                        b.validator,
+                                        b.signature
+                                )
+                        );
                 } else {
                         this.blocks = [Block.genesis];
                 }
@@ -23,12 +32,16 @@ class Blockchain {
                 saveValidators(this.validators);
         }
 
-        addBlock(data, validatorKey){
-                if(!this.validators[validatorKey]){
+        addBlock(data, validatorWallet) {
+                const vKey =
+                        typeof validatorWallet === 'string'
+                                ? validatorWallet
+                                : validatorWallet.publicKey;
+                if(!this.validators[vKey]){
                         throw Error('Validator has no stake');
                 }
                 const previousBlock = this.blocks[this.blocks.length - 1];
-                const block = Block.mine(previousBlock, data, validatorKey);
+                const block = Block.mine(previousBlock, data, validatorWallet);
                 this.blocks.push(block);
                 saveBlocks(this.blocks);
 

--- a/src/blockchain/modules/validator.js
+++ b/src/blockchain/modules/validator.js
@@ -1,4 +1,5 @@
 import Block from '../block.js';
+import { elliptic } from '../../modules/index.js';
 
 export default(blockchain) => {
 	const [genesisBlock, ...blocks] = blockchain;
@@ -11,7 +12,7 @@ export default(blockchain) => {
 	}
 
         for(let i = 0; i < blocks.length; i++){
-                const { previousHash, timestamp, data, hash, validator } = blocks[i];
+                const { previousHash, timestamp, data, hash, validator, signature } = blocks[i];
                 const previousBlock = blockchain[i];
 
                 if(previousHash !== previousBlock.hash){
@@ -19,6 +20,9 @@ export default(blockchain) => {
                 }
                 if(hash !== Block.hash(timestamp, previousHash, data, validator)){
                         throw Error('El hash es invalido');
+                }
+                if(!elliptic.verifySignature(validator, signature, hash)){
+                        throw Error('La firma del bloque es invalida');
                 }
         }
 

--- a/src/middleware/Api/Endpoints/ai_store.js
+++ b/src/middleware/Api/Endpoints/ai_store.js
@@ -4,7 +4,7 @@ export default (req, res) => {
     try {
         const block = newBlockchain.addBlock(
             { type: 'AI_DATA', model, description, hash: dataHash },
-            newWalletMiner.publicKey
+            newWalletMiner
         );
         p2pAction.sync();
         res.json({ status: 'ok', block });

--- a/src/middleware/Api/Endpoints/mine.js
+++ b/src/middleware/Api/Endpoints/mine.js
@@ -3,7 +3,7 @@ export default (req, res, next) => {
 	var blockchain = newBlockchain;
 
         const { 'body': {data} } = req;
-        const block = blockchain.addBlock(data, newWalletMiner.publicKey);
+        const block = blockchain.addBlock(data, newWalletMiner);
 	p2pAction.sync();
  	
  	res.json({

--- a/src/miner/miner.js
+++ b/src/miner/miner.js
@@ -18,8 +18,7 @@ class Miner {
                 }
 
                 memoryPool.transactions.push(Transaction.reward(wallet, blockchainWallet));
-                const validatorKey = blockchain.selectValidator() || wallet.publicKey;
-                const block = blockchain.addBlock(memoryPool.transactions, validatorKey);
+                const block = blockchain.addBlock(memoryPool.transactions, wallet);
                 p2p.sync();
                 memoryPool.wipe();
                 p2p.broadcast(MESSAGE.WIPE);


### PR DESCRIPTION
## Summary
- add a `signature` field to `Block`
- sign block hashes when mining and persist the signature
- verify the block signature in chain validation
- update endpoints and miner to pass wallet object
- include regression tests for signature verification

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855dc984c188329b222f8ea29fdce24