### PR TITLE
Add Next.js frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ datasets or model checkpoints while tokens can be used to incentivise agents.
    ```bash
    npm install
    npm start
+   npm run front
    ```
 
-2. Open `http://localhost:8000` in your browser to access the web interface.
+2. Open `http://localhost:3000` in your browser to access the new Next.js front end.
+   The blockchain API continues to run on `http://localhost:8000`.
 
 Chain data is automatically saved to disk so blocks remain after you restart the server.
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start:4": "PORT=3003 P2P_PORT=6003 PORTS=ws:localhost:6000 node ./src/service/index.js",
     "start:ex": "node ./ejemplo_mine.js",
     "nodemon": "nodemon ./src/service/index.js",
+    "front": "next dev -p 3000",
     "eslint": "eslint index.js src",
     "test": "jest",
     "test:watch": "jest --watchAll"
@@ -38,7 +39,10 @@
     "elliptic": "^6.5.2",
     "express": "^4.17.1",
     "uuid": "^7.0.2",
-    "ws": "^7.2.1"
+    "ws": "^7.2.1",
+    "next": "13.4.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
   },
   "jest": {
     "silent": false,

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,15 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        <script src="https://cdn.tailwindcss.com"></script>
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,167 @@
+import { useState, useEffect } from 'react';
+
+const API_BASE = 'http://localhost:8000';
+
+export default function Home() {
+  const [wallet, setWallet] = useState(null);
+  const [balanceAddress, setBalanceAddress] = useState('');
+  const [balance, setBalance] = useState(null);
+  const [recipient, setRecipient] = useState('');
+  const [amount, setAmount] = useState('');
+  const [transactionResult, setTransactionResult] = useState(null);
+  const [model, setModel] = useState('');
+  const [description, setDescription] = useState('');
+  const [dataHash, setDataHash] = useState('');
+  const [blocks, setBlocks] = useState([]);
+  const [chainStatus, setChainStatus] = useState(null);
+  const [chainLength, setChainLength] = useState(0);
+  const [validators, setValidators] = useState(null);
+  const [hashInput, setHashInput] = useState('');
+  const [blockInfo, setBlockInfo] = useState(null);
+
+  useEffect(() => {
+    refreshBlocks();
+    verifyChain();
+    loadValidators();
+  }, []);
+
+  async function createWallet() {
+    const res = await fetch(`${API_BASE}/api/wallet/new`, { method: 'POST' });
+    const json = await res.json();
+    setWallet(json.data);
+    setBalanceAddress(json.data.publicKey);
+    await getBalance(json.data.publicKey);
+  }
+
+  async function getBalance(addr) {
+    const address = addr || balanceAddress;
+    if (!address) return;
+    const res = await fetch(`${API_BASE}/api/balance/${address}`);
+    const json = await res.json();
+    setBalance(json);
+  }
+
+  async function sendTransaction() {
+    const amt = parseFloat(amount);
+    const res = await fetch(`${API_BASE}/api/transactions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ recipient, amount: amt })
+    });
+    const json = await res.json();
+    setTransactionResult(json);
+  }
+
+  async function storeAIData() {
+    await fetch(`${API_BASE}/api/ai/store`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model, description, dataHash })
+    });
+    refreshBlocks();
+  }
+
+  async function mineTransactions() {
+    await fetch(`${API_BASE}/api/mine/transactions`);
+    refreshBlocks();
+  }
+
+  async function refreshBlocks() {
+    const res = await fetch(`${API_BASE}/api/blocks`);
+    const json = await res.json();
+    setBlocks(json);
+  }
+
+  async function verifyChain() {
+    const res = await fetch(`${API_BASE}/api/verify`);
+    const json = await res.json();
+    setChainStatus(json);
+    const blocksRes = await fetch(`${API_BASE}/api/blocks`);
+    const blockJson = await blocksRes.json();
+    setChainLength(blockJson.length);
+  }
+
+  async function loadValidators() {
+    const res = await fetch(`${API_BASE}/api/validators`);
+    const json = await res.json();
+    setValidators(json);
+  }
+
+  async function getBlock() {
+    if (!hashInput) return;
+    const res = await fetch(`${API_BASE}/api/block/${hashInput}`);
+    const json = await res.json();
+    setBlockInfo(json);
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-10 px-4">
+      <h1 className="text-2xl font-bold mb-6 text-center">SuniCoin Blockchain Explorer</h1>
+
+      <section className="mb-8 max-w-xl mx-auto bg-white p-6 rounded shadow">
+        <h2 className="text-xl font-semibold mb-4">Wallet</h2>
+        <button onClick={createWallet} className="px-4 py-2 bg-blue-500 text-white rounded">Create Wallet</button>
+        <pre className="mt-4 bg-gray-100 p-4 rounded overflow-auto">{wallet && JSON.stringify(wallet, null, 2)}</pre>
+        <div className="mt-4 flex items-end gap-2">
+          <input value={balanceAddress} onChange={e => setBalanceAddress(e.target.value)} placeholder="address" className="flex-1 border p-2 rounded" />
+          <button onClick={() => getBalance()} className="px-4 py-2 bg-blue-500 text-white rounded">Balance</button>
+        </div>
+        <pre className="mt-2 bg-gray-100 p-4 rounded overflow-auto">{balance && JSON.stringify(balance, null, 2)}</pre>
+      </section>
+
+      <section className="mb-8 max-w-xl mx-auto bg-white p-6 rounded shadow">
+        <h2 className="text-xl font-semibold mb-4">Create Transaction</h2>
+        <div className="flex flex-col gap-2">
+          <input value={recipient} onChange={e => setRecipient(e.target.value)} placeholder="recipient address" className="border p-2 rounded" />
+          <input value={amount} onChange={e => setAmount(e.target.value)} type="number" placeholder="amount" className="border p-2 rounded" />
+          <button onClick={sendTransaction} className="px-4 py-2 bg-green-500 text-white rounded">Send</button>
+        </div>
+        <pre className="mt-4 bg-gray-100 p-4 rounded overflow-auto">{transactionResult && JSON.stringify(transactionResult, null, 2)}</pre>
+      </section>
+
+      <section className="mb-8 max-w-xl mx-auto bg-white p-6 rounded shadow">
+        <h2 className="text-xl font-semibold mb-4">Store AI Data</h2>
+        <div className="flex flex-col gap-2">
+          <input value={model} onChange={e => setModel(e.target.value)} placeholder="model name" className="border p-2 rounded" />
+          <input value={description} onChange={e => setDescription(e.target.value)} placeholder="description" className="border p-2 rounded" />
+          <input value={dataHash} onChange={e => setDataHash(e.target.value)} placeholder="data hash" className="border p-2 rounded" />
+          <button onClick={storeAIData} className="px-4 py-2 bg-indigo-500 text-white rounded">Save AI Data</button>
+        </div>
+      </section>
+
+      <section className="mb-8 text-center">
+        <button onClick={mineTransactions} className="px-4 py-2 bg-purple-500 text-white rounded">Mine Transactions</button>
+      </section>
+
+      <section className="max-w-xl mx-auto bg-white p-6 rounded shadow">
+        <h2 className="text-xl font-semibold mb-4">Blocks</h2>
+        <button onClick={refreshBlocks} className="px-4 py-2 bg-blue-500 text-white rounded">Refresh Blocks</button>
+        <pre className="mt-4 bg-gray-100 p-4 rounded overflow-auto">{JSON.stringify(blocks, null, 2)}</pre>
+      </section>
+
+      <section className="max-w-xl mx-auto bg-white p-6 mt-8 rounded shadow">
+        <h2 className="text-xl font-semibold mb-4">Chain</h2>
+        <div className="flex items-end gap-2 mb-2">
+          <button onClick={verifyChain} className="px-4 py-2 bg-green-600 text-white rounded">Verify</button>
+          <span className="ml-auto text-sm text-gray-600">{chainLength ? `${chainLength} blocks` : ''}</span>
+        </div>
+        <pre className="bg-gray-100 p-4 rounded overflow-auto">{chainStatus && JSON.stringify(chainStatus, null, 2)}</pre>
+      </section>
+
+      <section className="max-w-xl mx-auto bg-white p-6 mt-8 rounded shadow">
+        <h2 className="text-xl font-semibold mb-4">Validators</h2>
+        <button onClick={loadValidators} className="px-4 py-2 bg-blue-500 text-white rounded">Load Validators</button>
+        <pre className="mt-4 bg-gray-100 p-4 rounded overflow-auto">{validators && JSON.stringify(validators, null, 2)}</pre>
+      </section>
+
+      <section className="max-w-xl mx-auto bg-white p-6 mt-8 rounded shadow">
+        <h2 className="text-xl font-semibold mb-4">Block Lookup</h2>
+        <div className="flex items-end gap-2">
+          <input value={hashInput} onChange={e => setHashInput(e.target.value)} placeholder="block hash" className="flex-1 border p-2 rounded" />
+          <button onClick={getBlock} className="px-4 py-2 bg-blue-500 text-white rounded">Find</button>
+        </div>
+        <pre className="mt-4 bg-gray-100 p-4 rounded overflow-auto">{blockInfo && JSON.stringify(blockInfo, null, 2)}</pre>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Next.js with React
- include Next dev script and dependencies
- build a basic Next React page using API server
- document new front-end port and usage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855e0beb1588329b46240347d8cc8ee
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a Next.js frontend with React to provide a web interface for blockchain actions like wallet creation, transactions, and block exploration on port 3000.

- **New Features**
  - Built a basic Next.js app with pages for wallet, transactions, block explorer, and validator info.
  - Added scripts and dependencies for running the frontend alongside the API server.
  - Updated documentation with usage and port details.

<!-- End of auto-generated description by cubic. -->

