### PR TITLE
Add dev script to launch blockchain and frontend together

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ datasets or model checkpoints while tokens can be used to incentivise agents.
 
    ```bash
    npm install
-   npm start
-   npm run front
-   ```
+   npm run dev
+  ```
 
 2. Open `http://localhost:3000` in your browser to access the new Next.js front end.
    The blockchain API continues to run on `http://localhost:8000`.

--- a/dev.js
+++ b/dev.js
@@ -1,0 +1,22 @@
+import { spawn } from 'child_process';
+
+const processes = [];
+
+function start(cmd, args) {
+  const proc = spawn(cmd, args, { stdio: 'inherit', shell: true });
+  processes.push(proc);
+}
+
+start('npm', ['run', 'nodemon']);
+start('npm', ['run', 'front']);
+
+function shutdown() {
+  for (const p of processes) {
+    p.kill();
+  }
+  process.exit();
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start:ex": "node ./ejemplo_mine.js",
     "nodemon": "nodemon ./src/service/index.js",
     "front": "next dev -p 3000",
+    "dev": "node ./dev.js",
     "eslint": "eslint index.js src",
     "test": "jest",
     "test:watch": "jest --watchAll"


### PR DESCRIPTION
## Summary
- add `dev.js` script to run blockchain and Next.js concurrently
- expose `npm run dev` in package.json
- document the new command in README

## Testing
- `npm run dev` *(fails: nodemon and next not found)*
- `npm test` *(fails: jest not found)*
- `npm run eslint` *(fails: configuration missing)*

------
https://chatgpt.com/codex/tasks/task_b_6855e2480de88329847b0d71f16a045c
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new dev script to start both the blockchain backend and Next.js frontend with a single command.

- **New Features**
  - Introduced dev.js to launch both services together.
  - Added npm run dev to package.json.
  - Updated README with the new command.

<!-- End of auto-generated description by cubic. -->

