### PR TITLE
Fix Next.js Babel preset

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env"]
+  "presets": ["next/babel"]
 }

--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ blocks are created in real time.
 - Verify that the chain is valid and view the total block count
 - Search for a block by its hash
 
+## Troubleshooting
+
+If `npm run dev` fails with a message like `Cannot find module '@babel/preset-env'`,
+make sure dependencies are installed by running `npm install` first. The
+project now uses the built-in `next/babel` preset so no extra Babel packages are
+required once dependencies have been installed.
+
 ### Community
 
 Developer: [Edinsoncs](https://edinsoncs.com) - Edinson Carranza Saldaña


### PR DESCRIPTION
## Summary
- switch `.babelrc` to use `next/babel`
- add troubleshooting note in README about installing dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855e6370a1c83299a8c0f749a6c667c
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switched the Babel preset to use next/babel and added a troubleshooting note in the README for missing dependencies.

<!-- End of auto-generated description by cubic. -->

