### PR TITLE
Enable Next.js frontend with CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ datasets or model checkpoints while tokens can be used to incentivise agents.
 
 2. Open `http://localhost:3000` in your browser to access the new Next.js front end.
    The blockchain API continues to run on `http://localhost:8000`.
+   Cross-origin requests are allowed so the UI can communicate with the API while both servers run on different ports.
 
 Chain data is automatically saved to disk so blocks remain after you restart the server.
 

--- a/src/service/index.js
+++ b/src/service/index.js
@@ -17,6 +17,16 @@ global.newMiner = new Miner(newBlockchain, p2pAction, newWalletMiner);
 
 
 app.use(bodyParser.json());
+// Allow cross-origin requests so the Next.js frontend can call the API
+app.use((req, res, next) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  if (req.method === 'OPTIONS') {
+    return res.sendStatus(200);
+  }
+  next();
+});
 middleware(app);
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- allow CORS requests from the Next.js UI
- document how the frontend communicates with the API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855e85700dc8329b99de74275f49eff
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enabled CORS so the Next.js frontend can communicate with the API when running on different ports.

- **Documentation**
  - Updated the README to explain cross-origin support for the frontend and API.

<!-- End of auto-generated description by cubic. -->

