### PR TITLE
Add Tailwind explorer interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # SUNI
 
 SUNI is an experimental Proof‑of‑Stake blockchain written in Node.js. It includes
-a lightweight wallet, mining utilities and a simple web interface styled with
-Tailwind CSS.  The project is focused on exploring how blockchain technology can
+a lightweight wallet, mining utilities and a web interface styled with
+Tailwind CSS. The Next.js frontend now offers a basic explorer in the spirit of
+Etherscan or Solscan. The project is focused on exploring how blockchain technology can
 be used alongside Artificial Intelligence. The chain can store AI dataset or
 model information so researchers can track and share their assets.
 
@@ -80,7 +81,8 @@ this file whenever new blocks are added, ensuring persistence between restarts.
 
 - Node.js 18 or later is recommended.
 - REST API endpoints are defined in `src/middleware/Api/Endpoints`.
-- Frontend files live in `src/public` and use Tailwind CSS via CDN.
+- Frontend pages are built with Next.js under `pages/` and styled with
+  Tailwind CSS via CDN.
 - The blockchain core can be found under `src/blockchain`.
 - Chain data is saved to `src/storage/chain.json` so your history persists across restarts.
 - Helper methods now let you verify the chain, query balances and inspect validator stakes.
@@ -98,6 +100,7 @@ blocks are created in real time.
 - Load the current validator list and their stakes
 - Verify that the chain is valid and view the total block count
 - Search for a block by its hash
+- Browse blocks in a table via the new **Blocks** section
 
 ## Troubleshooting
 

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+
+export default function Layout({ children }) {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-gray-800 text-white">
+        <nav className="max-w-5xl mx-auto flex justify-between items-center p-4">
+          <Link href="/" className="font-semibold hover:underline">SUNI Explorer</Link>
+          <div className="space-x-4">
+            <Link href="/blocks" className="hover:underline">Blocks</Link>
+          </div>
+        </nav>
+      </header>
+      <main className="max-w-5xl mx-auto p-4">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,9 @@
+import Layout from '../components/Layout';
+
+export default function App({ Component, pageProps }) {
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  );
+}

--- a/pages/blocks/[hash].js
+++ b/pages/blocks/[hash].js
@@ -1,0 +1,29 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+const API_BASE = 'http://localhost:8000';
+
+export default function BlockDetail() {
+  const router = useRouter();
+  const { hash } = router.query;
+  const [block, setBlock] = useState(null);
+
+  useEffect(() => {
+    if (hash) {
+      fetch(`${API_BASE}/api/block/${hash}`)
+        .then(res => res.json())
+        .then(setBlock);
+    }
+  }, [hash]);
+
+  if (!block) return <p>Loading...</p>;
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4 break-all">Block {hash}</h1>
+      <pre className="bg-gray-100 p-4 overflow-auto rounded">
+        {JSON.stringify(block, null, 2)}
+      </pre>
+    </div>
+  );
+}

--- a/pages/blocks/index.js
+++ b/pages/blocks/index.js
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+const API_BASE = 'http://localhost:8000';
+
+export default function BlocksPage() {
+  const [blocks, setBlocks] = useState([]);
+
+  useEffect(() => {
+    fetch(`${API_BASE}/api/blocks`).then(res => res.json()).then(setBlocks);
+  }, []);
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Blocks</h1>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm text-left">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="px-2 py-1">#</th>
+              <th className="px-2 py-1">Hash</th>
+              <th className="px-2 py-1">Validator</th>
+              <th className="px-2 py-1">Time</th>
+              <th className="px-2 py-1">Txs</th>
+            </tr>
+          </thead>
+          <tbody>
+            {blocks.map((b, idx) => (
+              <tr key={b.hash} className="border-b last:border-none">
+                <td className="px-2 py-1">{blocks.length - idx - 1}</td>
+                <td className="px-2 py-1 truncate">
+                  <Link href={`/blocks/${b.hash}`} className="text-blue-600 hover:underline">
+                    {b.hash.slice(0, 20)}...
+                  </Link>
+                </td>
+                <td className="px-2 py-1 truncate">{b.validator}</td>
+                <td className="px-2 py-1">{new Date(b.timestamp).toLocaleString()}</td>
+                <td className="px-2 py-1">{Array.isArray(b.data) ? b.data.length : 1}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -95,8 +95,11 @@ export default function Home() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 py-10 px-4">
-      <h1 className="text-2xl font-bold mb-6 text-center">SuniCoin Blockchain Explorer</h1>
+    <div className="py-6">
+      <h1 className="text-2xl font-bold mb-2 text-center">SuniCoin Dashboard</h1>
+      <p className="text-center mb-6">
+        <a href="/blocks" className="text-blue-600 hover:underline">Browse Blocks</a>
+      </p>
 
       <section className="mb-8 max-w-xl mx-auto bg-white p-6 rounded shadow">
         <h2 className="text-xl font-semibold mb-4">Wallet</h2>


### PR DESCRIPTION
## Summary
- add Layout component and global _app.js
- create Blocks listing and detail pages
- tweak dashboard header and README documentation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855eaefa07c832984af8eadbff09cff
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a Tailwind-styled explorer interface with a blocks table and detail view, plus a shared layout for navigation.

- **New Features**
  - Blocks page lists all blocks in a table with links to details.
  - Block detail page shows full block data.
  - Layout component adds a header and navigation across pages.
  - Updated dashboard to link to the new explorer.

<!-- End of auto-generated description by cubic. -->

