### PR TITLE
Add address transaction explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The REST API exposes several helpers for querying the chain:
 - `GET /api/verify` – check whether the chain is valid
 - `GET /api/block/:hash` – fetch a block by its hash
 - `GET /api/balance/:address` – show the balance of a wallet address
+- `GET /api/address/:address/transactions` – list all transactions involving an address
 - `GET /api/ai/list` – list all blocks that contain AI data
 
 ### Blockchain Utilities
@@ -101,6 +102,7 @@ blocks are created in real time.
 - Verify that the chain is valid and view the total block count
 - Search for a block by its hash
 - Browse blocks in a table via the new **Blocks** section
+- Search for an address to view its balance and transactions
 
 ## Troubleshooting
 

--- a/pages/address/[address].js
+++ b/pages/address/[address].js
@@ -1,0 +1,51 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+const API_BASE = 'http://localhost:8000';
+
+export default function AddressPage() {
+  const router = useRouter();
+  const { address } = router.query;
+  const [balance, setBalance] = useState(null);
+  const [transactions, setTransactions] = useState([]);
+
+  useEffect(() => {
+    if (!address) return;
+    fetch(`${API_BASE}/api/balance/${address}`).then(res => res.json()).then(setBalance);
+    fetch(`${API_BASE}/api/address/${address}/transactions`).then(res => res.json()).then(setTransactions);
+  }, [address]);
+
+  if (!address) return <p>Loading...</p>;
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold break-all mb-4">Address {address}</h1>
+      {balance && (
+        <div className="bg-gray-100 p-4 rounded mb-4">
+          <p>Balance: {balance.balance}</p>
+        </div>
+      )}
+      <h2 className="text-lg font-semibold mb-2">Transactions</h2>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm text-left">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="px-2 py-1">Block</th>
+              <th className="px-2 py-1">Details</th>
+            </tr>
+          </thead>
+          <tbody>
+            {transactions.map((t, idx) => (
+              <tr key={idx} className="border-b last:border-none">
+                <td className="px-2 py-1">{t.blockIndex}</td>
+                <td className="px-2 py-1">
+                  <pre className="whitespace-pre-wrap break-all">{JSON.stringify(t.transaction, null, 2)}</pre>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
 
 const API_BASE = 'http://localhost:8000';
 
 export default function Home() {
+  const router = useRouter();
   const [wallet, setWallet] = useState(null);
   const [balanceAddress, setBalanceAddress] = useState('');
   const [balance, setBalance] = useState(null);
@@ -18,6 +20,7 @@ export default function Home() {
   const [validators, setValidators] = useState(null);
   const [hashInput, setHashInput] = useState('');
   const [blockInfo, setBlockInfo] = useState(null);
+  const [searchAddress, setSearchAddress] = useState('');
 
   useEffect(() => {
     refreshBlocks();
@@ -66,6 +69,11 @@ export default function Home() {
     refreshBlocks();
   }
 
+  function searchAddressPage() {
+    if (!searchAddress) return;
+    router.push(`/address/${searchAddress}`);
+  }
+
   async function refreshBlocks() {
     const res = await fetch(`${API_BASE}/api/blocks`);
     const json = await res.json();
@@ -100,6 +108,10 @@ export default function Home() {
       <p className="text-center mb-6">
         <a href="/blocks" className="text-blue-600 hover:underline">Browse Blocks</a>
       </p>
+      <div className="mb-6 max-w-xl mx-auto flex items-end gap-2">
+        <input value={searchAddress} onChange={e => setSearchAddress(e.target.value)} placeholder="search address" className="flex-1 border p-2 rounded" />
+        <button onClick={searchAddressPage} className="px-4 py-2 bg-blue-500 text-white rounded">Search</button>
+      </div>
 
       <section className="mb-8 max-w-xl mx-auto bg-white p-6 rounded shadow">
         <h2 className="text-xl font-semibold mb-4">Wallet</h2>

--- a/src/blockchain/blockchain.js
+++ b/src/blockchain/blockchain.js
@@ -119,6 +119,23 @@ class Blockchain {
                 return entries[0][0];
         }
 
+        getTransactionsForAddress(address){
+                const txs = [];
+                this.blocks.forEach((block, index) => {
+                        const { data = [] } = block;
+                        if(Array.isArray(data)){
+                                data.forEach((tx) => {
+                                        const involved = tx.input?.address === address ||
+                                                (Array.isArray(tx.outputs) && tx.outputs.some(o => o.address === address));
+                                        if(involved){
+                                                txs.push({ blockIndex: index, transaction: tx });
+                                        }
+                                });
+                        }
+                });
+                return txs;
+        }
+
 }
 
 export default Blockchain;

--- a/src/middleware/Api/Endpoints/address_transactions.js
+++ b/src/middleware/Api/Endpoints/address_transactions.js
@@ -1,0 +1,5 @@
+export default (req, res) => {
+    const { address } = req.params;
+    const txs = newBlockchain.getTransactionsForAddress(address);
+    res.json(txs);
+};

--- a/src/middleware/Api/Endpoints/index.js
+++ b/src/middleware/Api/Endpoints/index.js
@@ -14,6 +14,7 @@ import validators from './validators.js';
 import verify from './verify.js';
 import blockGet from './block_get.js';
 import balance from './balance.js';
+import addressTransactions from './address_transactions.js';
 
 const r = express.Router();
 
@@ -44,6 +45,9 @@ r.route('/block/:hash')
 
 r.route('/balance/:address')
 .get(balance);
+
+r.route('/address/:address/transactions')
+.get(addressTransactions);
 
 r.route('/ai/list')
 .get(aiList);


### PR DESCRIPTION
## Summary
- expose new API to list transactions for an address
- support searching addresses on the homepage
- add `/address/[address]` page showing balance and transactions
- update Blockchain with helper to fetch address transactions
- document new endpoint and feature

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855ec9bdcfc83299c7ff1f55b55c694
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an address explorer with a new API to list transactions for any address, plus a page to view address balances and transactions.

- **New Features**
  - Search for addresses from the homepage.
  - View address details and transactions at `/address/[address]`.
  - New API endpoint: `GET /api/address/:address/transactions`.

<!-- End of auto-generated description by cubic. -->

