### PR TITLE
Add profile and metadata pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,20 @@ blocks are created in real time.
 - Verify that the chain is valid and view the total block count
 - Search for a block by its hash
 - Browse blocks in a table via the new **Blocks** section
+- Manage your wallet from the **Profile** page and submit metadata to the chain
 - Search for an address to view its balance and transactions
+
+## Professional Overview
+
+BYDChain is designed to showcase core blockchain concepts in a clear and
+research‑friendly way. The validator selection process follows a simple
+Proof‑of‑Stake mechanism and the API provides endpoints for inspecting
+every aspect of the chain. Tokens are awarded when a wallet is created so
+new users can immediately experiment with transactions and staking.
+
+The Next.js frontend now includes additional pages for wallet management,
+browsing blocks and submitting metadata. Modern icons and webfonts give the
+UI a polished feel while keeping the codebase lightweight.
 
 ## Troubleshooting
 

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,13 +1,24 @@
 import Link from 'next/link';
+import { FaHome, FaCubes, FaUser, FaDatabase } from 'react-icons/fa';
 
 export default function Layout({ children }) {
   return (
     <div className="min-h-screen bg-gray-50">
       <header className="bg-gray-800 text-white">
         <nav className="max-w-5xl mx-auto flex justify-between items-center p-4">
-          <Link href="/" className="font-semibold hover:underline">BYDChain Explorer</Link>
-          <div className="space-x-4">
-            <Link href="/blocks" className="hover:underline">Blocks</Link>
+          <Link href="/" className="font-semibold hover:underline flex items-center gap-1">
+            <FaHome /> Home
+          </Link>
+          <div className="space-x-4 flex items-center">
+            <Link href="/blocks" className="hover:underline flex items-center gap-1">
+              <FaCubes /> Blocks
+            </Link>
+            <Link href="/metadata" className="hover:underline flex items-center gap-1">
+              <FaDatabase /> Metadata
+            </Link>
+            <Link href="/profile" className="hover:underline flex items-center gap-1">
+              <FaUser /> Profile
+            </Link>
           </div>
         </nav>
       </header>

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "ws": "^7.2.1",
     "next": "13.4.4",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "react-icons": "^4.10.1"
   },
   "jest": {
     "silent": false,

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -5,8 +5,12 @@ export default function Document() {
     <Html>
       <Head>
         <script src="https://cdn.tailwindcss.com"></script>
+        <link
+          href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&family=Raleway:wght@400;700&display=swap"
+          rel="stylesheet"
+        />
       </Head>
-      <body>
+      <body style={{ fontFamily: 'Nunito, Raleway, sans-serif' }}>
         <Main />
         <NextScript />
       </body>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { FaCubes } from 'react-icons/fa';
 import { useRouter } from 'next/router';
 
 const API_BASE = 'http://localhost:8000';
@@ -104,7 +105,12 @@ export default function Home() {
 
   return (
     <div className="py-6">
-      <h1 className="text-2xl font-bold mb-2 text-center">BYDChain Dashboard</h1>
+      <div className="text-center mb-6">
+        <h1 className="text-3xl font-bold flex justify-center items-center gap-2 mb-2">
+          <FaCubes className="text-purple-600" /> BYDChain Dashboard
+        </h1>
+        <p className="text-gray-700">Explore a simple Proof-of-Stake blockchain.</p>
+      </div>
       <p className="text-center mb-6">
         <a href="/blocks" className="text-blue-600 hover:underline">Browse Blocks</a>
       </p>

--- a/pages/metadata.js
+++ b/pages/metadata.js
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+
+const API_BASE = 'http://localhost:8000';
+
+export default function Metadata() {
+  const [model, setModel] = useState('');
+  const [description, setDescription] = useState('');
+  const [dataHash, setDataHash] = useState('');
+  const [result, setResult] = useState(null);
+
+  async function storeData() {
+    const res = await fetch(`${API_BASE}/api/ai/store`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model, description, dataHash })
+    });
+    const json = await res.json();
+    setResult(json);
+  }
+
+  return (
+    <div className="max-w-xl mx-auto py-6">
+      <h1 className="text-2xl font-bold mb-4 flex items-center gap-2">
+        Store Metadata
+      </h1>
+      <div className="flex flex-col gap-2">
+        <input
+          value={model}
+          onChange={e => setModel(e.target.value)}
+          placeholder="model name"
+          className="border p-2 rounded"
+        />
+        <input
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          placeholder="description"
+          className="border p-2 rounded"
+        />
+        <input
+          value={dataHash}
+          onChange={e => setDataHash(e.target.value)}
+          placeholder="data hash"
+          className="border p-2 rounded"
+        />
+        <button
+          onClick={storeData}
+          className="px-4 py-2 bg-indigo-500 text-white rounded"
+        >
+          Save
+        </button>
+      </div>
+      {result && (
+        <pre className="mt-4 bg-gray-100 p-4 rounded overflow-auto">
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+
+const API_BASE = 'http://localhost:8000';
+
+export default function Profile() {
+  const [password, setPassword] = useState('');
+  const [wallet, setWallet] = useState(null);
+
+  async function createWallet() {
+    const res = await fetch(`${API_BASE}/api/wallet/new`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password })
+    });
+    const json = await res.json();
+    setWallet(json.data);
+  }
+
+  return (
+    <div className="max-w-xl mx-auto py-6">
+      <h1 className="text-2xl font-bold mb-4 flex items-center gap-2">
+        Create Wallet
+      </h1>
+      <div className="flex flex-col gap-2 mb-4">
+        <input
+          type="password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          placeholder="password"
+          className="border p-2 rounded"
+        />
+        <button
+          onClick={createWallet}
+          className="px-4 py-2 bg-blue-500 text-white rounded"
+        >
+          Create
+        </button>
+      </div>
+      {wallet && (
+        <pre className="bg-gray-100 p-4 rounded overflow-auto">
+          {JSON.stringify(wallet, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/src/middleware/Api/Endpoints/wallet_new.js
+++ b/src/middleware/Api/Endpoints/wallet_new.js
@@ -1,13 +1,14 @@
 import Wallet from '../../../wallet/index.js';
 
 
-export default (req, res, next) => {
+export default (req, res) => {
+        const { password } = req.body || {};
+        const wallet = new Wallet(newBlockchain, 20);
+        wallet.password = password;
+        global.wallet_new = wallet;
 
-	global.wallet_new = new Wallet(newBlockchain, 20);
-
-	res.json({
-		status: 'ok',
-		data: wallet_new.blockchainWallet()
-	});
-
+        res.json({
+                status: 'ok',
+                data: wallet.blockchainWallet()
+        });
 };


### PR DESCRIPTION
## Summary
- create new Profile page with wallet creation form
- add Metadata page for saving metadata on-chain
- enhance layout navigation with icons
- include Google fonts Nunito and Raleway
- show hero section on home page
- allow wallet creation endpoint to accept password
- document new UI sections in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855f47000708329a9df23a9c04dd1e1
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added new Profile and Metadata pages for wallet creation and on-chain metadata storage, updated navigation with icons, and improved UI with Google fonts and a hero section.

- **New Features**
  - Profile page with wallet creation form (supports password).
  - Metadata page for saving metadata to the chain.
  - Navigation now uses icons; hero section added to home.
  - Google fonts Nunito and Raleway included.
  - Wallet creation endpoint now accepts a password.
  - README updated with new UI sections.

<!-- End of auto-generated description by cubic. -->

