### PR TITLE
Add simple contract scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Each block will contain fields `model`, `description` and `hash` so you can
 track AI assets over time. List all recorded AI blocks via
 `GET /api/ai/list`.
 
+### Smart Contract Scripts
+
+Transactions may include a small JavaScript snippet stored in the `script`
+field. When new blocks are validated these scripts are executed in a sandboxed
+VM. The block is rejected if any script returns `false`. This allows simple
+conditions such as enforcing minimum payments or custom rules without a full
+virtual machine.
+
 ### API Endpoints
 
 The REST API exposes several helpers for querying the chain:

--- a/__tests__/script_engine.test.js
+++ b/__tests__/script_engine.test.js
@@ -1,0 +1,21 @@
+import Blockchain from '../src/blockchain/index.js';
+import Wallet from '../src/wallet/index.js';
+import Transaction from '../src/wallet/transaction.js';
+
+describe('Transaction script validation', () => {
+    test('valid script keeps chain valid', () => {
+        const bc = new Blockchain();
+        const wallet = new Wallet(bc, 50);
+        const tx = Transaction.create(wallet, 'receiver', 10, 'true');
+        bc.addBlock([tx], wallet);
+        expect(bc.verifyChain()).toBe(true);
+    });
+
+    test('failing script invalidates chain', () => {
+        const bc = new Blockchain();
+        const wallet = new Wallet(bc, 50);
+        const tx = Transaction.create(wallet, 'receiver', 10, 'false');
+        bc.addBlock([tx], wallet);
+        expect(bc.verifyChain()).toBe(false);
+    });
+});

--- a/src/blockchain/modules/validator.js
+++ b/src/blockchain/modules/validator.js
@@ -1,5 +1,5 @@
 import Block from '../block.js';
-import { elliptic } from '../../modules/index.js';
+import { elliptic, runScript } from '../../modules/index.js';
 
 export default(blockchain) => {
 	const [genesisBlock, ...blocks] = blockchain;
@@ -23,6 +23,17 @@ export default(blockchain) => {
                 }
                 if(!elliptic.verifySignature(validator, signature, hash)){
                         throw Error('La firma del bloque es invalida');
+                }
+
+                if(Array.isArray(data)){
+                        for(const tx of data){
+                                if(tx.script){
+                                        const ok = runScript(tx.script, { tx });
+                                        if(!ok){
+                                                throw Error('Script de transaccion invalido');
+                                        }
+                                }
+                        }
                 }
         }
 

--- a/src/middleware/Api/Endpoints/transactions_new.js
+++ b/src/middleware/Api/Endpoints/transactions_new.js
@@ -1,11 +1,11 @@
 import { MESSAGE } from '../../../service/p2p.js';
 
 export default (req, res, next) => {
-	const { body: { recipient, amount }} = req;
-	try{
-		const tr = wallet_new.createTransaction(recipient, amount);
-		p2pAction.broadcast(MESSAGE.TR, tr);
-		res.json(tr);
+        const { body: { recipient, amount, script }} = req;
+        try{
+                const tr = wallet_new.createTransaction(recipient, amount, script);
+                p2pAction.broadcast(MESSAGE.TR, tr);
+                res.json(tr);
 	}catch(error){
 		res.json({ 
 			status: 0,

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -1,4 +1,5 @@
 import elliptic from './elliptic.js';
 import gnHash from './hash.js';
+import runScript from './scriptEngine.js';
 
-export { elliptic, gnHash};
+export { elliptic, gnHash, runScript };

--- a/src/modules/scriptEngine.js
+++ b/src/modules/scriptEngine.js
@@ -1,0 +1,14 @@
+import vm from 'vm';
+
+export default function runScript(code, context = {}) {
+    const sandbox = { ...context };
+    const script = new vm.Script(code);
+    const ctx = vm.createContext(sandbox);
+    try {
+        const result = script.runInContext(ctx, { timeout: 100 });
+        return result === true;
+    } catch (err) {
+        console.error('Script execution failed:', err);
+        return false;
+    }
+}

--- a/src/wallet/wallet.js
+++ b/src/wallet/wallet.js
@@ -45,7 +45,7 @@ class Wallet{
         }
 
 
-	createTransaction(receptAddress, amount){
+        createTransaction(receptAddress, amount, script = null){
 		const { blockchain: { memoryPool } } = this;
 
 		const balance = this.calculateBalance();
@@ -54,13 +54,13 @@ class Wallet{
 		   throw Error(`El monto es: ${amount} superior al balance: ${balance}`);
 		}
 
-		let tr = memoryPool.find(this.publicKey);
-		if(tr){
-			tr.update(this, receptAddress, amount);
-		} else {
-			tr = Transaction.create(this, receptAddress, amount);
-			memoryPool.addOrUpdate(tr);
-		}
+                let tr = memoryPool.find(this.publicKey);
+                if(tr){
+                        tr.update(this, receptAddress, amount, script);
+                } else {
+                        tr = Transaction.create(this, receptAddress, amount, script);
+                        memoryPool.addOrUpdate(tr);
+                }
 
 		return tr;
 


### PR DESCRIPTION
## Summary
- allow transactions to contain a `script` string
- evaluate transaction scripts when validating blocks
- expose script engine through API and wallet helpers
- document smart contract script support
- test new script validation logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68566fd8d8ec8329bd2095e1ce715ad9
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for simple smart contract scripts in transactions, allowing custom validation logic during block processing.

- **New Features**
  - Transactions can include a JavaScript script for custom rules.
  - Scripts are run in a sandbox when validating blocks; blocks are rejected if any script returns false.
  - Script engine is exposed through the API and wallet helpers.
  - Documentation and tests added for script support.

<!-- End of auto-generated description by cubic. -->

