### PR TITLE
Add metrics API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The REST API exposes several helpers for querying the chain:
 - `GET /api/balance/:address` – show the balance of a wallet address
 - `GET /api/address/:address/transactions` – list all transactions involving an address
 - `GET /api/ai/list` – list all blocks that contain AI data
+- `GET /api/metrics` – retrieve overall blockchain statistics
 
 ### Blockchain Utilities
 

--- a/__tests__/metrics.test.js
+++ b/__tests__/metrics.test.js
@@ -1,0 +1,11 @@
+import Blockchain from '../src/blockchain/index.js';
+
+describe('Blockchain stats', () => {
+    test('returns basic statistics', () => {
+        const bc = new Blockchain();
+        const stats = bc.getStats();
+        expect(stats.chainLength).toBe(bc.blocks.length);
+        expect(stats.validators).toEqual(bc.getValidators());
+        expect(typeof stats.totalTransactions).toBe('number');
+    });
+});

--- a/src/blockchain/blockchain.js
+++ b/src/blockchain/blockchain.js
@@ -119,6 +119,23 @@ class Blockchain {
                 return entries[0][0];
         }
 
+        getStats(){
+                const chainLength = this.blocks.length;
+                let totalTransactions = 0;
+                this.blocks.forEach(({ data }) => {
+                        if(Array.isArray(data)){
+                                totalTransactions += data.length;
+                        } else if(data && data !== 'S-U-N-I') {
+                                totalTransactions += 1;
+                        }
+                });
+                return {
+                        chainLength,
+                        totalTransactions,
+                        validators: this.getValidators()
+                };
+        }
+
         getTransactionsForAddress(address){
                 const txs = [];
                 this.blocks.forEach((block, index) => {

--- a/src/middleware/Api/Endpoints/index.js
+++ b/src/middleware/Api/Endpoints/index.js
@@ -15,6 +15,7 @@ import verify from './verify.js';
 import blockGet from './block_get.js';
 import balance from './balance.js';
 import addressTransactions from './address_transactions.js';
+import metrics from './metrics.js';
 
 const r = express.Router();
 
@@ -51,6 +52,9 @@ r.route('/address/:address/transactions')
 
 r.route('/ai/list')
 .get(aiList);
+
+r.route('/metrics')
+.get(metrics);
 
 
 /**

--- a/src/middleware/Api/Endpoints/metrics.js
+++ b/src/middleware/Api/Endpoints/metrics.js
@@ -1,0 +1,4 @@
+export default (req, res) => {
+    const stats = newBlockchain.getStats();
+    res.json(stats);
+};


### PR DESCRIPTION
## Summary
- provide global blockchain stats via `getStats` method
- expose new `/api/metrics` endpoint
- document the new endpoint in README
- test coverage for stats method

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685673483cd48329a1c9a202a651d259
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new /api/metrics endpoint to provide global blockchain statistics, including chain length, total transactions, and validators.

- **New Features**
  - Added getStats method to the blockchain.
  - Exposed /api/metrics endpoint.
  - Updated README with endpoint details.
  - Added tests for the stats method.

<!-- End of auto-generated description by cubic. -->

