### PR TITLE
Add mnemonic wallet support

### DIFF
--- a/__tests__/wallet_mnemonic.test.js
+++ b/__tests__/wallet_mnemonic.test.js
@@ -1,0 +1,12 @@
+import Blockchain from '../src/blockchain/index.js';
+import Wallet from '../src/wallet/index.js';
+
+describe('Wallet mnemonic import/export', () => {
+    test('exported mnemonic can recreate wallet', () => {
+        const bc = new Blockchain();
+        const w1 = new Wallet(bc, 50);
+        const mnemonic = w1.exportMnemonic();
+        const w2 = Wallet.fromMnemonic(bc, mnemonic, 50);
+        expect(w2.publicKey).toBe(w1.publicKey);
+    });
+});

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "next": "13.4.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-icons": "^4.10.1"
+    "react-icons": "^4.10.1",
+    "bip39": "^3.0.4",
+    "bip32": "^5.2.0"
   },
   "jest": {
     "silent": false,

--- a/src/modules/elliptic.js
+++ b/src/modules/elliptic.js
@@ -5,10 +5,11 @@ const ec = new Elliptic.ec('secp256k1');
 
 export default {
 
-	createKeyPair: () => ec.genKeyPair(),
-	verifySignature: (publicKey, signature, data) => {
-		return ec.keyFromPublic(publicKey, 'hex').
-		verify(gnHash(data), signature);
-	}
+        createKeyPair: () => ec.genKeyPair(),
+        fromPrivate: (privKey) => ec.keyFromPrivate(privKey),
+        verifySignature: (publicKey, signature, data) => {
+                return ec.keyFromPublic(publicKey, 'hex').
+                verify(gnHash(data), signature);
+        }
 
 }


### PR DESCRIPTION
## Summary
- allow creating wallets from BIP39 mnemonics using bip32 derivation
- expose mnemonic export/import helpers
- support deriving keypair from private key
- add test for mnemonic based wallet creation

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685674f47a0c8329bf47436e03f9e01b