### PR TITLE
Fix bip32 version reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-dom": "18.2.0",
     "react-icons": "^4.10.1",
     "bip39": "^3.0.4",
-    "bip32": "^5.2.0"
+    "bip32": "^6.0.0"
   },
   "jest": {
     "silent": false,


### PR DESCRIPTION
## Summary
- update bip32 dependency to a valid version

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68567631c45883298bb50800d489c301
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the bip32 dependency to version 6.0.0 to fix an invalid version reference.

<!-- End of auto-generated description by cubic. -->

