### PR TITLE
Fix invalid bip32 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-dom": "18.2.0",
     "react-icons": "^4.10.1",
     "bip39": "^3.0.4",
-    "bip32": "^6.0.0"
+    "bip32": "^5.2.0"
   },
   "jest": {
     "silent": false,


### PR DESCRIPTION
## Summary
- update `bip32` dependency to a valid version

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856793220f48329ac13089f254b9b83
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the bip32 dependency in package.json to use a valid version and fix npm install errors.

<!-- End of auto-generated description by cubic. -->

