### PR TITLE
Add dark theme and admin panel

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,9 +1,9 @@
 import Link from 'next/link';
-import { FaHome, FaCubes, FaUser, FaDatabase } from 'react-icons/fa';
+import { FaHome, FaCubes, FaUser, FaDatabase, FaTools } from 'react-icons/fa';
 
 export default function Layout({ children }) {
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-900 text-gray-100">
       <header className="bg-gray-800 text-white">
         <nav className="max-w-5xl mx-auto flex justify-between items-center p-4">
           <Link href="/" className="font-semibold hover:underline flex items-center gap-1">
@@ -18,6 +18,9 @@ export default function Layout({ children }) {
             </Link>
             <Link href="/profile" className="hover:underline flex items-center gap-1">
               <FaUser /> Profile
+            </Link>
+            <Link href="/admin" className="hover:underline flex items-center gap-1">
+              <FaTools /> Admin
             </Link>
           </div>
         </nav>

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-dom": "18.2.0",
     "react-icons": "^4.10.1",
     "bip39": "^3.0.4",
-    "bip32": "^5.2.0"
+    "bip32": "^2.0.6"
   },
   "jest": {
     "silent": false,

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -10,7 +10,7 @@ export default function Document() {
           rel="stylesheet"
         />
       </Head>
-      <body style={{ fontFamily: 'Nunito, Raleway, sans-serif' }}>
+      <body className="bg-gray-900 text-gray-100" style={{ fontFamily: 'Nunito, Raleway, sans-serif' }}>
         <Main />
         <NextScript />
       </body>

--- a/pages/address/[address].js
+++ b/pages/address/[address].js
@@ -21,14 +21,14 @@ export default function AddressPage() {
     <div>
       <h1 className="text-xl font-bold break-all mb-4">Address {address}</h1>
       {balance && (
-        <div className="bg-gray-100 p-4 rounded mb-4">
+        <div className="bg-gray-700 p-4 rounded mb-4">
           <p>Balance: {balance.balance}</p>
         </div>
       )}
       <h2 className="text-lg font-semibold mb-2">Transactions</h2>
       <div className="overflow-x-auto">
         <table className="min-w-full text-sm text-left">
-          <thead className="bg-gray-100">
+          <thead className="bg-gray-800">
             <tr>
               <th className="px-2 py-1">Block</th>
               <th className="px-2 py-1">Details</th>
@@ -39,7 +39,7 @@ export default function AddressPage() {
               <tr key={idx} className="border-b last:border-none">
                 <td className="px-2 py-1">{t.blockIndex}</td>
                 <td className="px-2 py-1">
-                  <pre className="whitespace-pre-wrap break-all">{JSON.stringify(t.transaction, null, 2)}</pre>
+                  <pre className="whitespace-pre-wrap break-all bg-gray-700 p-2 rounded">{JSON.stringify(t.transaction, null, 2)}</pre>
                 </td>
               </tr>
             ))}

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+const API_BASE = 'http://localhost:8000';
+
+export default function Admin() {
+  const [metrics, setMetrics] = useState(null);
+  const [nodes, setNodes] = useState([]);
+  const [blocks, setBlocks] = useState([]);
+
+  useEffect(() => {
+    fetch(`${API_BASE}/api/metrics`).then(res => res.json()).then(setMetrics);
+    fetch(`${API_BASE}/api/nodes`).then(res => res.json()).then(setNodes);
+    fetch(`${API_BASE}/api/blocks`).then(res => res.json()).then(setBlocks);
+  }, []);
+
+  return (
+    <div className="py-6 space-y-6">
+      <h1 className="text-3xl font-bold mb-4">Admin Panel</h1>
+
+      <section className="bg-gray-800 p-4 rounded shadow">
+        <h2 className="text-xl font-semibold mb-2">Metrics</h2>
+        <pre className="bg-gray-700 p-3 rounded overflow-auto">{metrics && JSON.stringify(metrics, null, 2)}</pre>
+      </section>
+
+      <section className="bg-gray-800 p-4 rounded shadow">
+        <h2 className="text-xl font-semibold mb-2">Nodes</h2>
+        <pre className="bg-gray-700 p-3 rounded overflow-auto">{JSON.stringify(nodes, null, 2)}</pre>
+      </section>
+
+      <section className="bg-gray-800 p-4 rounded shadow">
+        <h2 className="text-xl font-semibold mb-2">Blocks</h2>
+        <pre className="bg-gray-700 p-3 rounded overflow-auto">{JSON.stringify(blocks, null, 2)}</pre>
+      </section>
+    </div>
+  );
+}

--- a/pages/blocks/[hash].js
+++ b/pages/blocks/[hash].js
@@ -21,7 +21,7 @@ export default function BlockDetail() {
   return (
     <div>
       <h1 className="text-xl font-bold mb-4 break-all">Block {hash}</h1>
-      <pre className="bg-gray-100 p-4 overflow-auto rounded">
+      <pre className="bg-gray-700 p-4 overflow-auto rounded">
         {JSON.stringify(block, null, 2)}
       </pre>
     </div>

--- a/pages/blocks/index.js
+++ b/pages/blocks/index.js
@@ -15,7 +15,7 @@ export default function BlocksPage() {
       <h1 className="text-2xl font-bold mb-4">Blocks</h1>
       <div className="overflow-x-auto">
         <table className="min-w-full text-sm text-left">
-          <thead className="bg-gray-100">
+          <thead className="bg-gray-800">
             <tr>
               <th className="px-2 py-1">#</th>
               <th className="px-2 py-1">Hash</th>

--- a/pages/index.js
+++ b/pages/index.js
@@ -107,9 +107,9 @@ export default function Home() {
     <div className="py-6">
       <div className="text-center mb-6">
         <h1 className="text-3xl font-bold flex justify-center items-center gap-2 mb-2">
-          <FaCubes className="text-purple-600" /> BYDChain Dashboard
+          <FaCubes className="text-purple-400" /> BYDChain Dashboard
         </h1>
-        <p className="text-gray-700">Explore a simple Proof-of-Stake blockchain.</p>
+        <p className="text-gray-300">Explore a simple Proof-of-Stake blockchain.</p>
       </div>
       <p className="text-center mb-6">
         <a href="/blocks" className="text-blue-600 hover:underline">Browse Blocks</a>
@@ -119,33 +119,33 @@ export default function Home() {
         <button onClick={searchAddressPage} className="px-4 py-2 bg-blue-500 text-white rounded">Search</button>
       </div>
 
-      <section className="mb-8 max-w-xl mx-auto bg-white p-6 rounded shadow">
+      <section className="mb-8 max-w-xl mx-auto bg-gray-800 p-6 rounded shadow">
         <h2 className="text-xl font-semibold mb-4">Wallet</h2>
         <button onClick={createWallet} className="px-4 py-2 bg-blue-500 text-white rounded">Create Wallet</button>
-        <pre className="mt-4 bg-gray-100 p-4 rounded overflow-auto">{wallet && JSON.stringify(wallet, null, 2)}</pre>
+        <pre className="mt-4 bg-gray-700 p-4 rounded overflow-auto">{wallet && JSON.stringify(wallet, null, 2)}</pre>
         <div className="mt-4 flex items-end gap-2">
-          <input value={balanceAddress} onChange={e => setBalanceAddress(e.target.value)} placeholder="address" className="flex-1 border p-2 rounded" />
+          <input value={balanceAddress} onChange={e => setBalanceAddress(e.target.value)} placeholder="address" className="flex-1 border p-2 rounded bg-gray-700 text-gray-100" />
           <button onClick={() => getBalance()} className="px-4 py-2 bg-blue-500 text-white rounded">Balance</button>
         </div>
-        <pre className="mt-2 bg-gray-100 p-4 rounded overflow-auto">{balance && JSON.stringify(balance, null, 2)}</pre>
+        <pre className="mt-2 bg-gray-700 p-4 rounded overflow-auto">{balance && JSON.stringify(balance, null, 2)}</pre>
       </section>
 
-      <section className="mb-8 max-w-xl mx-auto bg-white p-6 rounded shadow">
+      <section className="mb-8 max-w-xl mx-auto bg-gray-800 p-6 rounded shadow">
         <h2 className="text-xl font-semibold mb-4">Create Transaction</h2>
         <div className="flex flex-col gap-2">
-          <input value={recipient} onChange={e => setRecipient(e.target.value)} placeholder="recipient address" className="border p-2 rounded" />
-          <input value={amount} onChange={e => setAmount(e.target.value)} type="number" placeholder="amount" className="border p-2 rounded" />
+          <input value={recipient} onChange={e => setRecipient(e.target.value)} placeholder="recipient address" className="border p-2 rounded bg-gray-700 text-gray-100" />
+          <input value={amount} onChange={e => setAmount(e.target.value)} type="number" placeholder="amount" className="border p-2 rounded bg-gray-700 text-gray-100" />
           <button onClick={sendTransaction} className="px-4 py-2 bg-green-500 text-white rounded">Send</button>
         </div>
-        <pre className="mt-4 bg-gray-100 p-4 rounded overflow-auto">{transactionResult && JSON.stringify(transactionResult, null, 2)}</pre>
+        <pre className="mt-4 bg-gray-700 p-4 rounded overflow-auto">{transactionResult && JSON.stringify(transactionResult, null, 2)}</pre>
       </section>
 
-      <section className="mb-8 max-w-xl mx-auto bg-white p-6 rounded shadow">
+      <section className="mb-8 max-w-xl mx-auto bg-gray-800 p-6 rounded shadow">
         <h2 className="text-xl font-semibold mb-4">Store AI Data</h2>
         <div className="flex flex-col gap-2">
-          <input value={model} onChange={e => setModel(e.target.value)} placeholder="model name" className="border p-2 rounded" />
-          <input value={description} onChange={e => setDescription(e.target.value)} placeholder="description" className="border p-2 rounded" />
-          <input value={dataHash} onChange={e => setDataHash(e.target.value)} placeholder="data hash" className="border p-2 rounded" />
+          <input value={model} onChange={e => setModel(e.target.value)} placeholder="model name" className="border p-2 rounded bg-gray-700 text-gray-100" />
+          <input value={description} onChange={e => setDescription(e.target.value)} placeholder="description" className="border p-2 rounded bg-gray-700 text-gray-100" />
+          <input value={dataHash} onChange={e => setDataHash(e.target.value)} placeholder="data hash" className="border p-2 rounded bg-gray-700 text-gray-100" />
           <button onClick={storeAIData} className="px-4 py-2 bg-indigo-500 text-white rounded">Save AI Data</button>
         </div>
       </section>
@@ -154,34 +154,34 @@ export default function Home() {
         <button onClick={mineTransactions} className="px-4 py-2 bg-purple-500 text-white rounded">Mine Transactions</button>
       </section>
 
-      <section className="max-w-xl mx-auto bg-white p-6 rounded shadow">
+      <section className="max-w-xl mx-auto bg-gray-800 p-6 rounded shadow">
         <h2 className="text-xl font-semibold mb-4">Blocks</h2>
         <button onClick={refreshBlocks} className="px-4 py-2 bg-blue-500 text-white rounded">Refresh Blocks</button>
-        <pre className="mt-4 bg-gray-100 p-4 rounded overflow-auto">{JSON.stringify(blocks, null, 2)}</pre>
+        <pre className="mt-4 bg-gray-700 p-4 rounded overflow-auto">{JSON.stringify(blocks, null, 2)}</pre>
       </section>
 
-      <section className="max-w-xl mx-auto bg-white p-6 mt-8 rounded shadow">
+      <section className="max-w-xl mx-auto bg-gray-800 p-6 mt-8 rounded shadow">
         <h2 className="text-xl font-semibold mb-4">Chain</h2>
         <div className="flex items-end gap-2 mb-2">
           <button onClick={verifyChain} className="px-4 py-2 bg-green-600 text-white rounded">Verify</button>
-          <span className="ml-auto text-sm text-gray-600">{chainLength ? `${chainLength} blocks` : ''}</span>
+          <span className="ml-auto text-sm text-gray-400">{chainLength ? `${chainLength} blocks` : ''}</span>
         </div>
-        <pre className="bg-gray-100 p-4 rounded overflow-auto">{chainStatus && JSON.stringify(chainStatus, null, 2)}</pre>
+        <pre className="bg-gray-700 p-4 rounded overflow-auto">{chainStatus && JSON.stringify(chainStatus, null, 2)}</pre>
       </section>
 
-      <section className="max-w-xl mx-auto bg-white p-6 mt-8 rounded shadow">
+      <section className="max-w-xl mx-auto bg-gray-800 p-6 mt-8 rounded shadow">
         <h2 className="text-xl font-semibold mb-4">Validators</h2>
         <button onClick={loadValidators} className="px-4 py-2 bg-blue-500 text-white rounded">Load Validators</button>
-        <pre className="mt-4 bg-gray-100 p-4 rounded overflow-auto">{validators && JSON.stringify(validators, null, 2)}</pre>
+        <pre className="mt-4 bg-gray-700 p-4 rounded overflow-auto">{validators && JSON.stringify(validators, null, 2)}</pre>
       </section>
 
-      <section className="max-w-xl mx-auto bg-white p-6 mt-8 rounded shadow">
+      <section className="max-w-xl mx-auto bg-gray-800 p-6 mt-8 rounded shadow">
         <h2 className="text-xl font-semibold mb-4">Block Lookup</h2>
         <div className="flex items-end gap-2">
-          <input value={hashInput} onChange={e => setHashInput(e.target.value)} placeholder="block hash" className="flex-1 border p-2 rounded" />
+          <input value={hashInput} onChange={e => setHashInput(e.target.value)} placeholder="block hash" className="flex-1 border p-2 rounded bg-gray-700 text-gray-100" />
           <button onClick={getBlock} className="px-4 py-2 bg-blue-500 text-white rounded">Find</button>
         </div>
-        <pre className="mt-4 bg-gray-100 p-4 rounded overflow-auto">{blockInfo && JSON.stringify(blockInfo, null, 2)}</pre>
+        <pre className="mt-4 bg-gray-700 p-4 rounded overflow-auto">{blockInfo && JSON.stringify(blockInfo, null, 2)}</pre>
       </section>
     </div>
   );

--- a/pages/metadata.js
+++ b/pages/metadata.js
@@ -28,19 +28,19 @@ export default function Metadata() {
           value={model}
           onChange={e => setModel(e.target.value)}
           placeholder="model name"
-          className="border p-2 rounded"
+          className="border p-2 rounded bg-gray-700 text-gray-100"
         />
         <input
           value={description}
           onChange={e => setDescription(e.target.value)}
           placeholder="description"
-          className="border p-2 rounded"
+          className="border p-2 rounded bg-gray-700 text-gray-100"
         />
         <input
           value={dataHash}
           onChange={e => setDataHash(e.target.value)}
           placeholder="data hash"
-          className="border p-2 rounded"
+          className="border p-2 rounded bg-gray-700 text-gray-100"
         />
         <button
           onClick={storeData}
@@ -50,7 +50,7 @@ export default function Metadata() {
         </button>
       </div>
       {result && (
-        <pre className="mt-4 bg-gray-100 p-4 rounded overflow-auto">
+        <pre className="mt-4 bg-gray-700 p-4 rounded overflow-auto">
           {JSON.stringify(result, null, 2)}
         </pre>
       )}

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -27,7 +27,7 @@ export default function Profile() {
           value={password}
           onChange={e => setPassword(e.target.value)}
           placeholder="password"
-          className="border p-2 rounded"
+          className="border p-2 rounded bg-gray-700 text-gray-100"
         />
         <button
           onClick={createWallet}
@@ -37,7 +37,7 @@ export default function Profile() {
         </button>
       </div>
       {wallet && (
-        <pre className="bg-gray-100 p-4 rounded overflow-auto">
+        <pre className="bg-gray-700 p-4 rounded overflow-auto">
           {JSON.stringify(wallet, null, 2)}
         </pre>
       )}

--- a/src/middleware/Api/Endpoints/index.js
+++ b/src/middleware/Api/Endpoints/index.js
@@ -16,6 +16,7 @@ import blockGet from './block_get.js';
 import balance from './balance.js';
 import addressTransactions from './address_transactions.js';
 import metrics from './metrics.js';
+import nodes from './nodes.js';
 
 const r = express.Router();
 
@@ -55,6 +56,9 @@ r.route('/ai/list')
 
 r.route('/metrics')
 .get(metrics);
+
+r.route('/nodes')
+  .get(nodes);
 
 
 /**

--- a/src/middleware/Api/Endpoints/nodes.js
+++ b/src/middleware/Api/Endpoints/nodes.js
@@ -1,0 +1,8 @@
+export default (req, res) => {
+    const nodes = p2pAction.sockets.map(s => {
+        const addr = s._socket.remoteAddress;
+        const port = s._socket.remotePort;
+        return `${addr}:${port}`;
+    });
+    res.json(nodes);
+};


### PR DESCRIPTION
## Summary
- downgrade bip32 package to ^2.0.6
- implement `/api/nodes` endpoint
- create blockchain admin dashboard page
- make layout dark themed and link to admin panel
- update pages to use dark styles

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68567c6e1d7c8329b90c7b5e48a5b9ae
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a dark theme across all pages and introduced an admin panel for viewing blockchain metrics, nodes, and blocks.

- **New Features**
  - Created an admin dashboard at /admin with sections for metrics, nodes, and blocks.
  - Added a new /api/nodes endpoint to list connected nodes.

- **Refactors**
  - Updated all layouts and components to use dark styles.
  - Linked the admin panel in the main navigation.
  - Downgraded the bip32 package to version ^2.0.6.

<!-- End of auto-generated description by cubic. -->

