### PR TITLE
Add wallet management endpoints and UI

### DIFF
--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,25 +1,63 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 const API_BASE = 'http://localhost:8000';
 
 export default function Profile() {
   const [password, setPassword] = useState('');
-  const [wallet, setWallet] = useState(null);
+  const [mnemonic, setMnemonic] = useState('');
+  const [wallets, setWallets] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [transactions, setTransactions] = useState([]);
+
+  async function loadWallets() {
+    const res = await fetch(`${API_BASE}/api/wallet/list`);
+    const json = await res.json();
+    setWallets(json);
+  }
+
+  useEffect(() => { loadWallets(); }, []);
 
   async function createWallet() {
-    const res = await fetch(`${API_BASE}/api/wallet/new`, {
+    await fetch(`${API_BASE}/api/wallet/new`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ password })
     });
+    setPassword('');
+    loadWallets();
+  }
+
+  async function importWallet() {
+    await fetch(`${API_BASE}/api/wallet/import`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mnemonic })
+    });
+    setMnemonic('');
+    loadWallets();
+  }
+
+  async function exportWallet(address) {
+    const res = await fetch(`${API_BASE}/api/wallet/export`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ address })
+    });
     const json = await res.json();
-    setWallet(json.data);
+    if (json.mnemonic) alert(json.mnemonic);
+  }
+
+  async function selectWallet(address) {
+    setSelected(address);
+    const res = await fetch(`${API_BASE}/api/address/${address}/transactions`);
+    const json = await res.json();
+    setTransactions(json);
   }
 
   return (
     <div className="max-w-xl mx-auto py-6">
       <h1 className="text-2xl font-bold mb-4 flex items-center gap-2">
-        Create Wallet
+        Wallets
       </h1>
       <div className="flex flex-col gap-2 mb-4">
         <input
@@ -36,10 +74,50 @@ export default function Profile() {
           Create
         </button>
       </div>
-      {wallet && (
-        <pre className="bg-gray-700 p-4 rounded overflow-auto">
-          {JSON.stringify(wallet, null, 2)}
-        </pre>
+
+      <div className="flex flex-col gap-2 mb-6">
+        <input
+          value={mnemonic}
+          onChange={e => setMnemonic(e.target.value)}
+          placeholder="mnemonic"
+          className="border p-2 rounded bg-gray-700 text-gray-100"
+        />
+        <button
+          onClick={importWallet}
+          className="px-4 py-2 bg-blue-500 text-white rounded"
+        >
+          Import
+        </button>
+      </div>
+
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-2">My Wallets</h2>
+        {wallets.map(w => (
+          <div key={w.publicKey} className="bg-gray-800 p-3 rounded mb-2 flex items-center gap-2">
+            <button
+              onClick={() => selectWallet(w.publicKey)}
+              className="px-2 py-1 bg-green-500 text-white rounded"
+            >
+              Select
+            </button>
+            <button
+              onClick={() => exportWallet(w.publicKey)}
+              className="px-2 py-1 bg-indigo-500 text-white rounded"
+            >
+              Export
+            </button>
+            <span className="ml-2 break-all">{w.publicKey}</span>
+          </div>
+        ))}
+      </section>
+
+      {selected && (
+        <section>
+          <h2 className="text-xl font-semibold mb-2">Transactions</h2>
+          <pre className="bg-gray-700 p-4 rounded overflow-auto">
+            {JSON.stringify(transactions, null, 2)}
+          </pre>
+        </section>
       )}
     </div>
   );

--- a/src/middleware/Api/Endpoints/index.js
+++ b/src/middleware/Api/Endpoints/index.js
@@ -5,6 +5,9 @@ import mineTransactions from './transactions_mine.js';
 import walletNew from './wallet_new.js';
 import walletAccess from './wallet_access.js';
 import walletStake from './wallet_stake.js';
+import walletList from './wallet_list.js';
+import walletExport from './wallet_export.js';
+import walletImport from './wallet_import.js';
 import mine from './mine.js';
 import transactionsNew from './transactions_new.js';
 import aiStore from './ai_store.js';
@@ -60,6 +63,9 @@ r.route('/metrics')
 r.route('/nodes')
   .get(nodes);
 
+r.route('/wallet/list')
+  .get(walletList);
+
 
 /**
  * Methods Post
@@ -73,6 +79,12 @@ r.route('/wallet/access')
 
 r.route('/wallet/stake')
 .post(walletStake);
+
+r.route('/wallet/export')
+  .post(walletExport);
+
+r.route('/wallet/import')
+  .post(walletImport);
 
 
 r.route('/mine')

--- a/src/middleware/Api/Endpoints/wallet_export.js
+++ b/src/middleware/Api/Endpoints/wallet_export.js
@@ -1,0 +1,10 @@
+export default (req, res) => {
+    const { address } = req.body || {};
+    const wallets = global.wallets || [];
+    const wallet = wallets.find(w => w.publicKey === address);
+    if (!wallet) {
+        res.json({ status: 0, error: 'Wallet not found' });
+        return;
+    }
+    res.json({ status: 'ok', mnemonic: wallet.exportMnemonic() });
+};

--- a/src/middleware/Api/Endpoints/wallet_import.js
+++ b/src/middleware/Api/Endpoints/wallet_import.js
@@ -1,0 +1,13 @@
+import Wallet from '../../../wallet/index.js';
+
+export default (req, res) => {
+    const { mnemonic } = req.body || {};
+    try {
+        const wallet = Wallet.fromMnemonic(newBlockchain, mnemonic, 20);
+        if (!global.wallets) global.wallets = [];
+        global.wallets.push(wallet);
+        res.json({ status: 'ok', data: wallet.blockchainWallet() });
+    } catch (err) {
+        res.json({ status: 0, error: 'Invalid mnemonic' });
+    }
+};

--- a/src/middleware/Api/Endpoints/wallet_list.js
+++ b/src/middleware/Api/Endpoints/wallet_list.js
@@ -1,0 +1,4 @@
+export default (req, res) => {
+    const wallets = global.wallets || [];
+    res.json(wallets.map(w => w.blockchainWallet()));
+};

--- a/src/middleware/Api/Endpoints/wallet_new.js
+++ b/src/middleware/Api/Endpoints/wallet_new.js
@@ -6,6 +6,8 @@ export default (req, res) => {
         const wallet = new Wallet(newBlockchain, 20);
         wallet.password = password;
         global.wallet_new = wallet;
+        if(!global.wallets) global.wallets = [];
+        global.wallets.push(wallet);
 
         res.json({
                 status: 'ok',

--- a/src/service/index.js
+++ b/src/service/index.js
@@ -10,6 +10,7 @@ import middleware from '../middleware/index.js';
 const app = express();
 const { PORT = 8000 } = process.env;
 global.newBlockchain = new Blockchain();
+global.wallets = [];
 //global.newWallet = new Wallet(newBlockchain, 0);
 global.newWalletMiner = new Wallet(newBlockchain, 0);
 global.p2pAction = new P2PAction(newBlockchain);


### PR DESCRIPTION
## Summary
- track created wallets in memory
- add endpoints to list, import and export wallets
- update wallet creation to store wallets
- expose new wallet routes
- show wallet list and transactions in the profile page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6857337b3cc483298a70db505e213d1a
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added wallet management endpoints and a UI to list, create, import, and export wallets from the profile page.

- **New Features**
  - Endpoints to list, import, and export wallets.
  - Profile page now shows wallet list and transactions, with options to create, import, export, and select wallets.

<!-- End of auto-generated description by cubic. -->

