### PR TITLE
Add transaction status preview

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -12,6 +12,7 @@ export default function Home() {
   const [recipient, setRecipient] = useState('');
   const [amount, setAmount] = useState('');
   const [transactionResult, setTransactionResult] = useState(null);
+  const [transactionInfo, setTransactionInfo] = useState(null);
   const [model, setModel] = useState('');
   const [description, setDescription] = useState('');
   const [dataHash, setDataHash] = useState('');
@@ -54,6 +55,13 @@ export default function Home() {
     });
     const json = await res.json();
     setTransactionResult(json);
+    if (json.id) {
+      const infoRes = await fetch(`${API_BASE}/api/transaction/${json.id}`);
+      if (infoRes.ok) {
+        const infoJson = await infoRes.json();
+        setTransactionInfo(infoJson);
+      }
+    }
   }
 
   async function storeAIData() {
@@ -137,7 +145,25 @@ export default function Home() {
           <input value={amount} onChange={e => setAmount(e.target.value)} type="number" placeholder="amount" className="border p-2 rounded bg-gray-700 text-gray-100" />
           <button onClick={sendTransaction} className="px-4 py-2 bg-green-500 text-white rounded">Send</button>
         </div>
-        <pre className="mt-4 bg-gray-700 p-4 rounded overflow-auto">{transactionResult && JSON.stringify(transactionResult, null, 2)}</pre>
+        {transactionResult && (
+          <div className="mt-4 bg-gray-700 p-4 rounded">
+            <p className="mb-2">Transaction submitted.</p>
+            <p>
+              ID:{' '}
+              <a
+                href={`/tx/${transactionResult.id}`}
+                className="text-blue-400 underline"
+              >
+                {transactionResult.id}
+              </a>
+            </p>
+            {transactionInfo && (
+              <pre className="mt-2 overflow-auto">
+                {JSON.stringify(transactionInfo, null, 2)}
+              </pre>
+            )}
+          </div>
+        )}
       </section>
 
       <section className="mb-8 max-w-xl mx-auto bg-gray-800 p-6 rounded shadow">

--- a/pages/tx/[id].js
+++ b/pages/tx/[id].js
@@ -1,0 +1,35 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+const API_BASE = 'http://localhost:8000';
+
+export default function TransactionDetail() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [info, setInfo] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!id) return;
+    setLoading(true);
+    fetch(`${API_BASE}/api/transaction/${id}`)
+      .then(res => res.json())
+      .then(data => {
+        setInfo(data);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [id]);
+
+  if (loading) return <p>Loading...</p>;
+  if (!info) return <p>Transaction not found</p>;
+
+  return (
+    <div className="max-w-xl mx-auto py-6">
+      <h1 className="text-2xl font-bold mb-4 break-all">Transaction {id}</h1>
+      <pre className="bg-gray-700 p-4 rounded overflow-auto">
+        {JSON.stringify(info, null, 2)}
+      </pre>
+    </div>
+  );
+}

--- a/src/middleware/Api/Endpoints/index.js
+++ b/src/middleware/Api/Endpoints/index.js
@@ -16,6 +16,7 @@ import mempool from './mempool.js';
 import validators from './validators.js';
 import verify from './verify.js';
 import blockGet from './block_get.js';
+import transactionGet from './transaction_get.js';
 import balance from './balance.js';
 import addressTransactions from './address_transactions.js';
 import metrics from './metrics.js';
@@ -47,6 +48,9 @@ r.route('/verify')
 
 r.route('/block/:hash')
 .get(blockGet);
+
+r.route('/transaction/:id')
+  .get(transactionGet);
 
 r.route('/balance/:address')
 .get(balance);

--- a/src/middleware/Api/Endpoints/transaction_get.js
+++ b/src/middleware/Api/Endpoints/transaction_get.js
@@ -1,0 +1,23 @@
+export default (req, res) => {
+  const { id } = req.params;
+  const memTx = newBlockchain.memoryPool.transactions.find(t => t.id === id);
+  if (memTx) {
+    return res.json({ status: 'pending', transaction: memTx });
+  }
+
+  for (let i = newBlockchain.blocks.length - 1; i >= 0; i--) {
+    const { data } = newBlockchain.blocks[i];
+    if (Array.isArray(data)) {
+      const found = data.find(t => t.id === id);
+      if (found) {
+        return res.json({
+          status: 'confirmed',
+          blockIndex: i,
+          transaction: found
+        });
+      }
+    }
+  }
+
+  res.status(404).json({ error: 'Transaction not found' });
+};


### PR DESCRIPTION
## Summary
- add API route to fetch transaction status
- expose `/tx/[id]` page to show transaction info
- fetch transaction status after sending and link to new page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685735be0fb08329a60cafce5ee28671
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a transaction status preview feature. Users can now view transaction details and status after sending, with a new page for each transaction.

- **New Features**
  - Added API route to fetch transaction status by ID.
  - Created `/tx/[id]` page to display transaction info and status.
  - Linked transaction results to the new detail page from the main view.

<!-- End of auto-generated description by cubic. -->

