### PR TITLE
Add auto mining script and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ validator is now selected based on stake when new blocks are mined.
 
 You can inspect pending transactions via `GET /api/mempool`.
 
+### Mining Transactions
+
+Pending transfers remain in the mempool until a block is produced. You can
+manually confirm them from the UI by pressing **Mine Transactions** or by
+calling `GET /api/mine/transactions`.
+
+For unattended nodes run `npm run auto-mine` in a separate terminal. The script
+checks the mempool every few seconds and mines a new block whenever pending
+transactions are detected.
+
 The chain is loaded from `src/storage/chain.json` on start and saved back to
 this file whenever new blocks are added, ensuring persistence between restarts.
 

--- a/autoMiner.js
+++ b/autoMiner.js
@@ -1,0 +1,17 @@
+const API = 'http://localhost:8000';
+
+async function mineIfPending() {
+  try {
+    const memRes = await fetch(`${API}/api/mempool`);
+    const mem = await memRes.json();
+    if (Array.isArray(mem) && mem.length > 0) {
+      await fetch(`${API}/api/mine/transactions`);
+      console.log(`Mined ${mem.length} transaction(s)`);
+    }
+  } catch (err) {
+    console.error('Auto mining failed:', err.message);
+  }
+}
+
+setInterval(mineIfPending, 5000);
+console.log('Auto miner running...');

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start:3": "PORT=3002 P2P_PORT=6002 PORTS=ws:localhost:6000 node ./src/service/index.js",
     "start:4": "PORT=3003 P2P_PORT=6003 PORTS=ws:localhost:6000 node ./src/service/index.js",
     "start:ex": "node ./ejemplo_mine.js",
+    "auto-mine": "node ./autoMiner.js",
     "nodemon": "nodemon ./src/service/index.js",
     "front": "next dev -p 3000",
     "dev": "node ./dev.js",


### PR DESCRIPTION
## Summary
- add `autoMiner.js` helper script to mine pending transactions automatically
- document how to use it in README
- expose `npm run auto-mine` in package.json

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685739e446348329ad48b51ba0f47d72
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an auto-mining script to confirm pending transactions automatically and updated the README with usage instructions.

- **New Features**
  - Added autoMiner.js script to mine transactions when pending.
  - Added npm run auto-mine command for easy use.
  - Updated documentation with setup and usage details.

<!-- End of auto-generated description by cubic. -->

