### PR TITLE
Add extra blockchain utility methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Several helper methods are exposed through the `Blockchain` class:
   for a wallet.
 - `getStakeOf(key)` returns how many tokens a validator has staked.
 - `getValidators()` gives the full validator table.
+- `getBlockByIndex(i)` retrieves a block at a given chain index.
+- `getAllTransactions()` returns every transaction with its block index.
+- `getAverageBlockTime()` computes the average time difference between blocks in milliseconds.
 
 Validators are persisted to `src/storage/validators.json` and a random
 validator is now selected based on stake when new blocks are mined.

--- a/__tests__/blockchain_extra.test.js
+++ b/__tests__/blockchain_extra.test.js
@@ -1,0 +1,32 @@
+import Blockchain from '../src/blockchain/index.js';
+import Wallet from '../src/wallet/index.js';
+import Block from '../src/blockchain/block.js';
+
+describe('Additional blockchain functions', () => {
+  test('getBlockByIndex returns genesis and mined blocks', () => {
+    const bc = new Blockchain();
+    const wallet = new Wallet(bc, 0);
+    const mined = bc.addBlock('data', wallet);
+    expect(bc.getBlockByIndex(0)).toEqual(Block.genesis);
+    expect(bc.getBlockByIndex(1)).toEqual(mined);
+    expect(bc.getBlockByIndex(99)).toBeNull();
+  });
+
+  test('getAllTransactions aggregates transactions', () => {
+    const bc = new Blockchain();
+    const wallet = new Wallet(bc, 0);
+    bc.addBlock(['tx1', 'tx2'], wallet);
+    const txs = bc.getAllTransactions();
+    expect(txs.length).toBe(2);
+    expect(txs[0].blockIndex).toBe(1);
+  });
+
+  test('getAverageBlockTime returns positive number', () => {
+    const bc = new Blockchain();
+    const wallet = new Wallet(bc, 0);
+    bc.addBlock('a', wallet);
+    bc.addBlock('b', wallet);
+    const avg = bc.getAverageBlockTime();
+    expect(avg).toBeGreaterThan(0);
+  });
+});

--- a/src/blockchain/blockchain.js
+++ b/src/blockchain/blockchain.js
@@ -153,6 +153,30 @@ class Blockchain {
                 return txs;
         }
 
+        getBlockByIndex(index){
+                if(index < 0 || index >= this.blocks.length) return null;
+                return this.blocks[index];
+        }
+
+        getAllTransactions(){
+                const txs = [];
+                this.blocks.forEach(({ data = [] }, idx) => {
+                        if(Array.isArray(data)){
+                                data.forEach(tx => txs.push({ blockIndex: idx, transaction: tx }));
+                        }
+                });
+                return txs;
+        }
+
+        getAverageBlockTime(){
+                if(this.blocks.length < 2) return 0;
+                let totalDiff = 0;
+                for(let i = 1; i < this.blocks.length; i++){
+                        totalDiff += this.blocks[i].timestamp - this.blocks[i-1].timestamp;
+                }
+                return totalDiff / (this.blocks.length - 1);
+        }
+
 }
 
 export default Blockchain;


### PR DESCRIPTION
## Summary
- add `getBlockByIndex`, `getAllTransactions` and `getAverageBlockTime` helpers
- document new helpers
- test the new blockchain functions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6858807596188329a1050b4f963a11bb
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added three new blockchain helper methods: getBlockByIndex, getAllTransactions, and getAverageBlockTime. Updated documentation and added tests for these helpers.

- **New Features**
  - getBlockByIndex retrieves a block by its index.
  - getAllTransactions returns all transactions with their block index.
  - getAverageBlockTime calculates the average time between blocks.

<!-- End of auto-generated description by cubic. -->

