### PR TITLE
Add extended blockchain metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The REST API exposes several helpers for querying the chain:
 - `GET /api/address/:address/transactions` – list all transactions involving an address
 - `GET /api/ai/list` – list all blocks that contain AI data
 - `GET /api/metrics` – retrieve overall blockchain statistics
+- `GET /api/metrics/extended` – retrieve advanced network statistics
 
 ### Blockchain Utilities
 
@@ -77,6 +78,7 @@ Several helper methods are exposed through the `Blockchain` class:
   for a wallet.
 - `getStakeOf(key)` returns how many tokens a validator has staked.
 - `getValidators()` gives the full validator table.
+- `getExtendedStats()` provides advanced chain metrics.
 
 Validators are persisted to `src/storage/validators.json` and a random
 validator is now selected based on stake when new blocks are mined.

--- a/__tests__/metrics.test.js
+++ b/__tests__/metrics.test.js
@@ -1,4 +1,5 @@
 import Blockchain from '../src/blockchain/index.js';
+import Wallet from '../src/wallet/index.js';
 
 describe('Blockchain stats', () => {
     test('returns basic statistics', () => {
@@ -7,5 +8,18 @@ describe('Blockchain stats', () => {
         expect(stats.chainLength).toBe(bc.blocks.length);
         expect(stats.validators).toEqual(bc.getValidators());
         expect(typeof stats.totalTransactions).toBe('number');
+    });
+
+    test('returns extended statistics', () => {
+        const bc = new Blockchain();
+        const wallet = new Wallet(bc, 50);
+        wallet.stake(5);
+        const tx = wallet.createTransaction('receiver', 10);
+        bc.addBlock([tx], wallet);
+        const ext = bc.getExtendedStats();
+        expect(ext.totalStake).toBeGreaterThan(0);
+        expect(typeof ext.avgBlockTime).toBe('number');
+        expect(ext.uniqueAddresses).toBeGreaterThan(0);
+        expect(typeof ext.mempoolSize).toBe('number');
     });
 });

--- a/src/blockchain/blockchain.js
+++ b/src/blockchain/blockchain.js
@@ -184,6 +184,40 @@ class Blockchain {
                 return txs;
         }
 
+        /**
+         * Calculate extended network statistics
+         * @returns {Object}
+         */
+        getExtendedStats(){
+                const stats = this.getStats();
+
+                if(this.blocks.length > 1){
+                        const intervals = [];
+                        for(let i = 1; i < this.blocks.length; i++){
+                                intervals.push(this.blocks[i].timestamp - this.blocks[i - 1].timestamp);
+                        }
+                        stats.avgBlockTime = intervals.reduce((t, v) => t + v, 0) / intervals.length;
+                } else {
+                        stats.avgBlockTime = 0;
+                }
+
+                stats.totalStake = Object.values(this.validators)
+                        .reduce((t, v) => t + Number(v), 0);
+
+                stats.mempoolSize = this.memoryPool.transactions.length;
+
+                const addresses = new Set();
+                this.getAllTransactions().forEach(tx => {
+                        if(tx.input?.address) addresses.add(tx.input.address);
+                        if(Array.isArray(tx.outputs)){
+                                tx.outputs.forEach(o => addresses.add(o.address));
+                        }
+                });
+                stats.uniqueAddresses = addresses.size;
+
+                return stats;
+        }
+
 }
 
 export default Blockchain;

--- a/src/middleware/Api/Endpoints/index.js
+++ b/src/middleware/Api/Endpoints/index.js
@@ -20,6 +20,7 @@ import transactionGet from './transaction_get.js';
 import balance from './balance.js';
 import addressTransactions from './address_transactions.js';
 import metrics from './metrics.js';
+import metricsExtended from './metrics_extended.js';
 import nodes from './nodes.js';
 
 const r = express.Router();
@@ -63,6 +64,9 @@ r.route('/ai/list')
 
 r.route('/metrics')
 .get(metrics);
+
+r.route('/metrics/extended')
+  .get(metricsExtended);
 
 r.route('/nodes')
   .get(nodes);

--- a/src/middleware/Api/Endpoints/metrics_extended.js
+++ b/src/middleware/Api/Endpoints/metrics_extended.js
@@ -1,0 +1,4 @@
+export default (req, res) => {
+    const stats = newBlockchain.getExtendedStats();
+    res.json(stats);
+};


### PR DESCRIPTION
## Summary
- support `getExtendedStats` in blockchain for professional metrics
- expose `/api/metrics/extended` endpoint
- document new API route and utility method
- test extended stats output

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685881b555bc83298424ff2f63d6d23a