### PR TITLE
Integrate validator selection and refactor globals

### DIFF
--- a/src/blockchain/blockchain.js
+++ b/src/blockchain/blockchain.js
@@ -37,9 +37,22 @@ class Blockchain {
                         typeof validatorWallet === 'string'
                                 ? validatorWallet
                                 : validatorWallet.publicKey;
+
                 if(!this.validators[vKey]){
-                        throw Error('Validator has no stake');
+                        if(Object.keys(this.validators).length === 0){
+                                this.registerStake(vKey, 1);
+                        } else {
+                                throw Error('Validator has no stake');
+                        }
                 }
+
+                if(Object.keys(this.validators).length > 0){
+                        const selected = this.selectValidator();
+                        if(selected && selected !== vKey){
+                                throw Error('Validator not selected');
+                        }
+                }
+
                 const previousBlock = this.blocks[this.blocks.length - 1];
                 const block = Block.mine(previousBlock, data, validatorWallet);
                 this.blocks.push(block);

--- a/src/blockchain/modules/validator.js
+++ b/src/blockchain/modules/validator.js
@@ -12,13 +12,13 @@ export default(blockchain) => {
 	}
 
         for(let i = 0; i < blocks.length; i++){
-                const { previousHash, timestamp, data, hash, validator, signature } = blocks[i];
+                const { previousHash, timestamp, data, hash, validator, signature, difficulty } = blocks[i];
                 const previousBlock = blockchain[i];
 
                 if(previousHash !== previousBlock.hash){
                         throw Error('El anterior (Previous) hash es incorrecto');
                 }
-                if(hash !== Block.hash(timestamp, previousHash, data, validator)){
+                if(hash !== Block.hash(timestamp, previousHash, data, validator, difficulty)){
                         throw Error('El hash es invalido');
                 }
                 if(!elliptic.verifySignature(validator, signature, hash)){

--- a/src/middleware/Api/Endpoints/address_transactions.js
+++ b/src/middleware/Api/Endpoints/address_transactions.js
@@ -1,5 +1,7 @@
+import { blockchain } from '../../../service/context.js';
+
 export default (req, res) => {
     const { address } = req.params;
-    const txs = newBlockchain.getTransactionsForAddress(address);
+    const txs = blockchain.getTransactionsForAddress(address);
     res.json(txs);
 };

--- a/src/middleware/Api/Endpoints/ai_list.js
+++ b/src/middleware/Api/Endpoints/ai_list.js
@@ -1,5 +1,7 @@
+import { blockchain } from '../../../service/context.js';
+
 export default (req, res) => {
-    const aiBlocks = newBlockchain.blocks.filter(
+    const aiBlocks = blockchain.blocks.filter(
         ({ data }) => data && data.type === 'AI_DATA'
     );
     res.json(aiBlocks);

--- a/src/middleware/Api/Endpoints/ai_store.js
+++ b/src/middleware/Api/Endpoints/ai_store.js
@@ -1,10 +1,12 @@
 
+import { blockchain, walletMiner, p2pAction } from '../../../service/context.js';
+
 export default (req, res) => {
     const { model, description, dataHash } = req.body;
     try {
-        const block = newBlockchain.addBlock(
+        const block = blockchain.addBlock(
             { type: 'AI_DATA', model, description, hash: dataHash },
-            newWalletMiner
+            walletMiner
         );
         p2pAction.sync();
         res.json({ status: 'ok', block });

--- a/src/middleware/Api/Endpoints/balance.js
+++ b/src/middleware/Api/Endpoints/balance.js
@@ -1,5 +1,7 @@
+import { blockchain } from '../../../service/context.js';
+
 export default (req, res) => {
     const { address } = req.params;
-    const balance = newBlockchain.getBalance(address);
+    const balance = blockchain.getBalance(address);
     res.json({ address, balance });
 };

--- a/src/middleware/Api/Endpoints/block_get.js
+++ b/src/middleware/Api/Endpoints/block_get.js
@@ -1,6 +1,8 @@
+import { blockchain } from '../../../service/context.js';
+
 export default (req, res) => {
     const { hash } = req.params;
-    const block = newBlockchain.findBlockByHash(hash);
+    const block = blockchain.findBlockByHash(hash);
     if(block) {
         res.json(block);
     } else {

--- a/src/middleware/Api/Endpoints/blocks.js
+++ b/src/middleware/Api/Endpoints/blocks.js
@@ -1,4 +1,5 @@
-export default (req, res, next) => {
-	var blockchain = newBlockchain;
-	res.json(blockchain.blocks);
+import { blockchain } from '../../../service/context.js';
+
+export default (req, res) => {
+        res.json(blockchain.blocks);
 };

--- a/src/middleware/Api/Endpoints/mempool.js
+++ b/src/middleware/Api/Endpoints/mempool.js
@@ -1,3 +1,5 @@
+import { blockchain } from '../../../service/context.js';
+
 export default (req, res) => {
-    res.json(newBlockchain.memoryPool.transactions);
+    res.json(blockchain.memoryPool.transactions);
 };

--- a/src/middleware/Api/Endpoints/metrics.js
+++ b/src/middleware/Api/Endpoints/metrics.js
@@ -1,4 +1,6 @@
+import { blockchain } from '../../../service/context.js';
+
 export default (req, res) => {
-    const stats = newBlockchain.getStats();
+    const stats = blockchain.getStats();
     res.json(stats);
 };

--- a/src/middleware/Api/Endpoints/metrics_extended.js
+++ b/src/middleware/Api/Endpoints/metrics_extended.js
@@ -1,4 +1,6 @@
+import { blockchain } from '../../../service/context.js';
+
 export default (req, res) => {
-    const stats = newBlockchain.getExtendedStats();
+    const stats = blockchain.getExtendedStats();
     res.json(stats);
 };

--- a/src/middleware/Api/Endpoints/mine.js
+++ b/src/middleware/Api/Endpoints/mine.js
@@ -1,10 +1,10 @@
-export default (req, res, next) => {
+import { blockchain, walletMiner, p2pAction } from '../../../service/context.js';
 
-	var blockchain = newBlockchain;
+export default (req, res) => {
 
         const { 'body': {data} } = req;
-        const block = blockchain.addBlock(data, newWalletMiner);
-	p2pAction.sync();
+        const block = blockchain.addBlock(data, walletMiner);
+        p2pAction.sync();
  	
  	res.json({
  		'blocks': blockchain.blocks.length,

--- a/src/middleware/Api/Endpoints/nodes.js
+++ b/src/middleware/Api/Endpoints/nodes.js
@@ -1,3 +1,5 @@
+import { p2pAction } from '../../../service/context.js';
+
 export default (req, res) => {
     const nodes = p2pAction.sockets.map(s => {
         const addr = s._socket.remoteAddress;

--- a/src/middleware/Api/Endpoints/transaction_get.js
+++ b/src/middleware/Api/Endpoints/transaction_get.js
@@ -1,12 +1,14 @@
+import { blockchain } from '../../../service/context.js';
+
 export default (req, res) => {
   const { id } = req.params;
-  const memTx = newBlockchain.memoryPool.transactions.find(t => t.id === id);
+  const memTx = blockchain.memoryPool.transactions.find(t => t.id === id);
   if (memTx) {
     return res.json({ status: 'pending', transaction: memTx });
   }
 
-  for (let i = newBlockchain.blocks.length - 1; i >= 0; i--) {
-    const { data } = newBlockchain.blocks[i];
+  for (let i = blockchain.blocks.length - 1; i >= 0; i--) {
+    const { data } = blockchain.blocks[i];
     if (Array.isArray(data)) {
       const found = data.find(t => t.id === id);
       if (found) {

--- a/src/middleware/Api/Endpoints/transactions.js
+++ b/src/middleware/Api/Endpoints/transactions.js
@@ -1,6 +1,8 @@
-export default (req, res, next) => {
+import { blockchain } from '../../../service/context.js';
 
-	const { memoryPool: { transactions } }  = Blockchain;
-	res.json(transactions);
+export default (req, res) => {
+
+        const { memoryPool: { transactions } }  = blockchain;
+        res.json(transactions);
 
 };

--- a/src/middleware/Api/Endpoints/transactions_mine.js
+++ b/src/middleware/Api/Endpoints/transactions_mine.js
@@ -1,7 +1,9 @@
-export default (req, res, next) => {
+import { miner } from '../../../service/context.js';
+
+export default (req, res) => {
 
 	try{
-		newMiner.mine();
+                miner.mine();
 		res.redirect('/api/blocks');
 	}catch(error){
 		res.json({error: error.message});

--- a/src/middleware/Api/Endpoints/transactions_new.js
+++ b/src/middleware/Api/Endpoints/transactions_new.js
@@ -1,9 +1,10 @@
 import { MESSAGE } from '../../../service/p2p.js';
+import { currentWallet, p2pAction } from '../../../service/context.js';
 
 export default (req, res, next) => {
         const { body: { recipient, amount, script }} = req;
         try{
-                const tr = wallet_new.createTransaction(recipient, amount, script);
+                const tr = currentWallet.createTransaction(recipient, amount, script);
                 p2pAction.broadcast(MESSAGE.TR, tr);
                 res.json(tr);
 	}catch(error){

--- a/src/middleware/Api/Endpoints/validators.js
+++ b/src/middleware/Api/Endpoints/validators.js
@@ -1,3 +1,5 @@
+import { blockchain } from '../../../service/context.js';
+
 export default (req, res) => {
-    res.json(newBlockchain.getValidators());
+    res.json(blockchain.getValidators());
 };

--- a/src/middleware/Api/Endpoints/verify.js
+++ b/src/middleware/Api/Endpoints/verify.js
@@ -1,4 +1,6 @@
+import { blockchain } from '../../../service/context.js';
+
 export default (req, res) => {
-    const valid = newBlockchain.verifyChain();
+    const valid = blockchain.verifyChain();
     res.json({ valid });
 };

--- a/src/middleware/Api/Endpoints/wallet_access.js
+++ b/src/middleware/Api/Endpoints/wallet_access.js
@@ -1,19 +1,18 @@
-import Wallet from '../../../wallet/index.js';
+import { currentWallet } from '../../../service/context.js';
 
+export default (req, res) => {
 
-export default (req, res, next) => {
+        const my_wallet = currentWallet.sign(req.body.private);
 
-	const my_wallet = wallet_new.sign(req.body.private);
+        console.log(my_wallet);
 
-	console.log(my_wallet);
-
-	res.json({
-		status: 'ok',
-		data: {
-			publicKey: wallet_new.publicKey,
-			balance: wallet_new.balance
-		}
-	});
+        res.json({
+                status: 'ok',
+                data: {
+                        publicKey: currentWallet.publicKey,
+                        balance: currentWallet.balance
+                }
+        });
 
 
 };

--- a/src/middleware/Api/Endpoints/wallet_export.js
+++ b/src/middleware/Api/Endpoints/wallet_export.js
@@ -1,6 +1,7 @@
+import { wallets } from '../../../service/context.js';
+
 export default (req, res) => {
     const { address } = req.body || {};
-    const wallets = global.wallets || [];
     const wallet = wallets.find(w => w.publicKey === address);
     if (!wallet) {
         res.json({ status: 0, error: 'Wallet not found' });

--- a/src/middleware/Api/Endpoints/wallet_import.js
+++ b/src/middleware/Api/Endpoints/wallet_import.js
@@ -1,11 +1,12 @@
 import Wallet from '../../../wallet/index.js';
+import context, { blockchain, wallets } from '../../../service/context.js';
 
 export default (req, res) => {
     const { mnemonic } = req.body || {};
     try {
-        const wallet = Wallet.fromMnemonic(newBlockchain, mnemonic, 20);
-        if (!global.wallets) global.wallets = [];
-        global.wallets.push(wallet);
+        const wallet = Wallet.fromMnemonic(blockchain, mnemonic, 20);
+        wallets.push(wallet);
+        context.currentWallet = wallet;
         res.json({ status: 'ok', data: wallet.blockchainWallet() });
     } catch (err) {
         res.json({ status: 0, error: 'Invalid mnemonic' });

--- a/src/middleware/Api/Endpoints/wallet_list.js
+++ b/src/middleware/Api/Endpoints/wallet_list.js
@@ -1,4 +1,5 @@
+import { wallets } from '../../../service/context.js';
+
 export default (req, res) => {
-    const wallets = global.wallets || [];
     res.json(wallets.map(w => w.blockchainWallet()));
 };

--- a/src/middleware/Api/Endpoints/wallet_new.js
+++ b/src/middleware/Api/Endpoints/wallet_new.js
@@ -1,13 +1,12 @@
 import Wallet from '../../../wallet/index.js';
-
+import context, { blockchain, wallets } from '../../../service/context.js';
 
 export default (req, res) => {
         const { password } = req.body || {};
-        const wallet = new Wallet(newBlockchain, 20);
+        const wallet = new Wallet(blockchain, 20);
         wallet.password = password;
-        global.wallet_new = wallet;
-        if(!global.wallets) global.wallets = [];
-        global.wallets.push(wallet);
+        context.currentWallet = wallet;
+        wallets.push(wallet);
 
         res.json({
                 status: 'ok',

--- a/src/middleware/Api/Endpoints/wallet_stake.js
+++ b/src/middleware/Api/Endpoints/wallet_stake.js
@@ -1,12 +1,14 @@
 
 
 
-export default (req, res, next) => {
+import { currentWallet } from '../../../service/context.js';
+
+export default (req, res) => {
 
     const { body: { amount } } = req;
     try {
-        wallet_new.stake(Number(amount));
-        res.json({ status: 'ok', stake: wallet_new.stakeBalance });
+        currentWallet.stake(Number(amount));
+        res.json({ status: 'ok', stake: currentWallet.stakeBalance });
     } catch (error) {
         res.json({ status: 0, error: error.message });
     }

--- a/src/service/context.js
+++ b/src/service/context.js
@@ -1,0 +1,14 @@
+import Blockchain from '../blockchain/index.js';
+import P2PAction from './p2p.js';
+import Wallet from '../wallet/index.js';
+import Miner from '../miner/index.js';
+
+const blockchain = new Blockchain();
+const wallets = [];
+const walletMiner = new Wallet(blockchain, 0);
+const p2pAction = new P2PAction(blockchain);
+const miner = new Miner(blockchain, p2pAction, walletMiner);
+let currentWallet = null;
+
+export { blockchain, wallets, walletMiner, p2pAction, miner, currentWallet };
+export default { blockchain, wallets, walletMiner, p2pAction, miner, currentWallet };

--- a/src/service/index.js
+++ b/src/service/index.js
@@ -1,20 +1,11 @@
 import express from 'express';
 import bodyParser from 'body-parser';
-import Blockchain from '../blockchain/index.js';
-import P2PAction from './p2p.js';
-import Wallet from '../wallet/index.js';
-import Miner from '../miner/index.js';
+import context from './context.js';
 import middleware from '../middleware/index.js';
 
 
 const app = express();
 const { PORT = 8000 } = process.env;
-global.newBlockchain = new Blockchain();
-global.wallets = [];
-//global.newWallet = new Wallet(newBlockchain, 0);
-global.newWalletMiner = new Wallet(newBlockchain, 0);
-global.p2pAction = new P2PAction(newBlockchain);
-global.newMiner = new Miner(newBlockchain, p2pAction, newWalletMiner);
 
 
 app.use(bodyParser.json());
@@ -31,5 +22,5 @@ app.use((req, res, next) => {
 middleware(app);
 
 app.listen(PORT, () => {
-	p2pAction.listen();
+        context.p2pAction.listen();
 });


### PR DESCRIPTION
## Summary
- add a `context` module to hold blockchain state
- include difficulty in block mining and adjust automatically
- enforce validator selection and auto‑register first validator
- remove global state usage from API endpoints

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685882e58f1c8329ab38a8b6f895378f