### PR TITLE
Add Electron desktop build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ Chain data is automatically saved to disk so blocks remain after you restart the
 Multiple nodes can be launched using the extra `start:*` scripts in
 `package.json`.
 
+### Desktop Builds
+
+The same interface can be wrapped in an Electron shell so it runs like a
+regular application on Windows or macOS.
+
+```bash
+npm run build            # export the Next.js frontend
+npm run desktop:win      # create a Windows installer
+npm run desktop:mac      # create a macOS installer
+```
+
 ## How It Works
 
 BYDChain keeps a chain of blocks linked with hashes. Transactions are collected in a

--- a/main.js
+++ b/main.js
@@ -1,0 +1,22 @@
+import { app, BrowserWindow } from 'electron';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1024,
+    height: 768,
+    webPreferences: { nodeIntegration: false },
+  });
+
+  if (process.env.NODE_ENV === 'development') {
+    win.loadURL('http://localhost:3000');
+  } else {
+    win.loadFile(join(__dirname, 'out/index.html'));
+  }
+}
+
+app.whenReady().then(createWindow);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bydchain",
   "version": "0.0.1",
   "description": "bydchain.org",
-  "main": "index.js",
+  "main": "main.js",
   "type": "module",
   "scripts": {
     "start": "node ./src/service/index.js",
@@ -14,9 +14,16 @@
     "nodemon": "nodemon ./src/service/index.js",
     "front": "next dev -p 3000",
     "dev": "node ./dev.js",
+    "desktop:dev": "concurrently \"npm run front\" \"electron .\"",
     "eslint": "eslint index.js src",
     "test": "jest",
-    "test:watch": "jest --watchAll"
+    "test:watch": "jest --watchAll",
+    "build": "next build && next export",
+    "desktop:win": "electron-builder --win",
+    "desktop:mac": "electron-builder --mac"
+  },
+  "build": {
+    "files": ["out", "main.js"]
   },
   "repository": {
     "type": "git",
@@ -34,7 +41,10 @@
     "eslint-plugin-import": "^2.20.1",
     "jest": "^25.1.0",
     "nodemon": "^2.0.2",
-    "@babel/preset-env": "^7.8.6"
+    "@babel/preset-env": "^7.8.6",
+    "electron": "^28.2.1",
+    "electron-builder": "^24.6.0",
+    "concurrently": "^8.2.0"
   },
   "dependencies": {
     "body-parser": "^1.19.0",


### PR DESCRIPTION
## Summary
- add Electron entry file
- support packaging the Next.js front-end as a desktop app
- document how to build Windows and macOS installers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685ef5a8e25c832993b9526b530c1145
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added Electron support to package the Next.js app as a desktop application for Windows and macOS.

- **New Features**
  - Added Electron entry file and build scripts.
  - Documented steps to create Windows and macOS installers in the README.

<!-- End of auto-generated description by cubic. -->

