### PR TITLE
Start node API in packaged Electron build

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,6 +2,10 @@ import { app, BrowserWindow } from 'electron';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
+async function startApiServer() {
+  await import('./src/service/index.js');
+}
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
@@ -19,4 +23,9 @@ function createWindow() {
   }
 }
 
-app.whenReady().then(createWindow);
+app.whenReady().then(() => {
+  if (app.isPackaged) {
+    startApiServer();
+  }
+  createWindow();
+});

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "desktop:mac": "electron-builder --mac"
   },
   "build": {
-    "files": ["out", "main.js"]
+    "files": ["out", "main.js", "src/**/*"]
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- bundle the `src` folder in packaged apps
- launch the Node.js API automatically when the Electron app is packaged

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685f0169957083299c2f97ab3653f302