### PR TITLE
Enhance dashboard UI with theme toggle and modal

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { FaHome, FaCubes, FaUser, FaDatabase, FaTools } from 'react-icons/fa';
+import ThemeToggle from './ThemeToggle';
 
 export default function Layout({ children }) {
   return (
@@ -22,6 +23,7 @@ export default function Layout({ children }) {
             <Link href="/admin" className="hover:underline flex items-center gap-1">
               <FaTools /> Admin
             </Link>
+            <ThemeToggle />
           </div>
         </nav>
       </header>

--- a/components/Modal.js
+++ b/components/Modal.js
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+
+export default function Modal({ open, onClose, children }) {
+  useEffect(() => {
+    function esc(e) {
+      if (e.key === 'Escape') onClose();
+    }
+    if (open) document.addEventListener('keydown', esc);
+    return () => document.removeEventListener('keydown', esc);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <div className="bg-gray-800 p-6 rounded shadow max-w-lg w-full relative">
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-2 text-gray-400 hover:text-white"
+        >
+          &times;
+        </button>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/components/ThemeContext.js
+++ b/components/ThemeContext.js
@@ -1,0 +1,28 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+const ThemeContext = createContext();
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState('dark');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored) setTheme(stored);
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.classList.remove('light', 'dark');
+    document.documentElement.classList.add(theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/components/ThemeToggle.js
+++ b/components/ThemeToggle.js
@@ -1,0 +1,18 @@
+import { useTheme } from './ThemeContext';
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  function toggle() {
+    setTheme(theme === 'dark' ? 'light' : 'dark');
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      className="px-3 py-1 border rounded text-xs hover:bg-gray-700"
+    >
+      {theme === 'dark' ? 'Light' : 'Dark'} Mode
+    </button>
+  );
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,9 +1,12 @@
 import Layout from '../components/Layout';
+import { ThemeProvider } from '../components/ThemeContext';
 
 export default function App({ Component, pageProps }) {
   return (
-    <Layout>
-      <Component {...pageProps} />
-    </Layout>
+    <ThemeProvider>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </ThemeProvider>
   );
 }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -10,7 +10,10 @@ export default function Document() {
           rel="stylesheet"
         />
       </Head>
-      <body className="bg-black text-white" style={{ fontFamily: 'Nunito, Raleway, sans-serif' }}>
+      <body
+        className="bg-white text-black dark:bg-black dark:text-white"
+        style={{ fontFamily: 'Nunito, Raleway, sans-serif' }}
+      >
         <Main />
         <NextScript />
       </body>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { FaCubes } from 'react-icons/fa';
+import Modal from '../components/Modal';
 import { useRouter } from 'next/router';
 
 const API_BASE = 'http://localhost:8000';
@@ -23,6 +24,7 @@ export default function Home() {
   const [hashInput, setHashInput] = useState('');
   const [blockInfo, setBlockInfo] = useState(null);
   const [searchAddress, setSearchAddress] = useState('');
+  const [showTxModal, setShowTxModal] = useState(false);
 
   useEffect(() => {
     refreshBlocks();
@@ -55,6 +57,7 @@ export default function Home() {
     });
     const json = await res.json();
     setTransactionResult(json);
+    setShowTxModal(true);
     if (json.id) {
       const infoRes = await fetch(`${API_BASE}/api/transaction/${json.id}`);
       if (infoRes.ok) {
@@ -145,25 +148,24 @@ export default function Home() {
           <input value={amount} onChange={e => setAmount(e.target.value)} type="number" placeholder="amount" className="border p-2 rounded bg-gray-900 text-gray-100" />
           <button onClick={sendTransaction} className="px-4 py-2 bg-green-500 text-white rounded">Send</button>
         </div>
-        {transactionResult && (
-          <div className="mt-4 bg-gray-900 p-4 rounded">
-            <p className="mb-2">Transaction submitted.</p>
-            <p>
-              ID:{' '}
-              <a
-                href={`/tx/${transactionResult.id}`}
-                className="text-blue-400 underline"
-              >
-                {transactionResult.id}
-              </a>
-            </p>
-            {transactionInfo && (
-              <pre className="mt-2 overflow-auto">
-                {JSON.stringify(transactionInfo, null, 2)}
-              </pre>
-            )}
-          </div>
-        )}
+        <Modal open={showTxModal} onClose={() => setShowTxModal(false)}>
+          {transactionResult && (
+            <div>
+              <h3 className="text-lg font-semibold mb-2">Transaction Submitted</h3>
+              <p className="mb-2">
+                ID{' '}
+                <a href={`/tx/${transactionResult.id}`} className="text-blue-400 underline">
+                  {transactionResult.id}
+                </a>
+              </p>
+              {transactionInfo && (
+                <pre className="bg-gray-900 p-2 rounded overflow-auto">
+                  {JSON.stringify(transactionInfo, null, 2)}
+                </pre>
+              )}
+            </div>
+          )}
+        </Modal>
       </section>
 
       <section className="mb-8 max-w-xl mx-auto bg-black border border-gray-700 p-6 rounded shadow">


### PR DESCRIPTION
## Summary
- add theme context with toggle component
- use new ThemeProvider
- update layout with theme switcher
- support light/dark mode in `_document`
- display transaction info in modal dialog

## Testing
- `npm test` *(fails: jest not found)*
- `npm run eslint` *(fails: ESLint config not found)*

------
https://chatgpt.com/codex/tasks/task_b_68663cfd0cfc8329ad81a205f8b40641