### PR TITLE
Add address stats helper and endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The REST API exposes several helpers for querying the chain:
 - `GET /api/block/:hash` – fetch a block by its hash
 - `GET /api/balance/:address` – show the balance of a wallet address
 - `GET /api/address/:address/transactions` – list all transactions involving an address
+- `GET /api/address/:address/stats` – summarize sent and received amounts for an address
 - `GET /api/ai/list` – list all blocks that contain AI data
 - `GET /api/metrics` – retrieve overall blockchain statistics
 - `GET /api/metrics/extended` – retrieve advanced network statistics
@@ -90,6 +91,7 @@ Several helper methods are exposed through the `Blockchain` class:
 - `getStakeOf(key)` returns how many tokens a validator has staked.
 - `getValidators()` gives the full validator table.
 - `getExtendedStats()` provides advanced chain metrics.
+- `getAddressStats(address)` summarizes total sent and received amounts for an address.
 
 Validators are persisted to `src/storage/validators.json` and a random
 validator is now selected based on stake when new blocks are mined.

--- a/__tests__/address_stats.test.js
+++ b/__tests__/address_stats.test.js
@@ -1,0 +1,20 @@
+import Blockchain from '../src/blockchain/index.js';
+import Wallet from '../src/wallet/index.js';
+
+describe('Address statistics', () => {
+  test('getAddressStats aggregates sent and received', () => {
+    const bc = new Blockchain();
+    const w1 = new Wallet(bc, 50);
+    const w2 = new Wallet(bc, 50);
+    w1.stake(1);
+    const tx = w1.createTransaction(w2.publicKey, 10);
+    bc.addBlock([tx], w1);
+    const s1 = bc.getAddressStats(w1.publicKey);
+    const s2 = bc.getAddressStats(w2.publicKey);
+    expect(s1.sent).toBe(10);
+    expect(s1.received).toBe(39); // change output to self
+    expect(s1.txCount).toBe(1);
+    expect(s2.received).toBe(10);
+    expect(s2.sent).toBe(0);
+  });
+});

--- a/src/blockchain/blockchain.js
+++ b/src/blockchain/blockchain.js
@@ -167,6 +167,30 @@ class Blockchain {
         }
 
         /**
+         * Summarize activity for an address
+         * @param {string} address
+         * @returns {{txCount:number,sent:number,received:number}}
+         */
+        getAddressStats(address){
+                const txs = this.getTransactionsForAddress(address);
+                let sent = 0;
+                let received = 0;
+                txs.forEach(({ transaction }) => {
+                        if(transaction.input?.address === address){
+                                transaction.outputs.forEach(o => {
+                                        if(o.address !== address) sent += Number(o.amount);
+                                });
+                        }
+                        if(Array.isArray(transaction.outputs)){
+                                transaction.outputs.forEach(o => {
+                                        if(o.address === address) received += Number(o.amount);
+                                });
+                        }
+                });
+                return { txCount: txs.length, sent, received };
+        }
+
+        /**
          * Retrieve a block by its index in the chain
          * @param {number} index
          * @returns {Block|null}

--- a/src/middleware/Api/Endpoints/address_stats.js
+++ b/src/middleware/Api/Endpoints/address_stats.js
@@ -1,0 +1,7 @@
+import { blockchain } from '../../../service/context.js';
+
+export default (req, res) => {
+    const { address } = req.params;
+    const stats = blockchain.getAddressStats(address);
+    res.json(stats);
+};

--- a/src/middleware/Api/Endpoints/index.js
+++ b/src/middleware/Api/Endpoints/index.js
@@ -19,6 +19,7 @@ import blockGet from './block_get.js';
 import transactionGet from './transaction_get.js';
 import balance from './balance.js';
 import addressTransactions from './address_transactions.js';
+import addressStats from './address_stats.js';
 import metrics from './metrics.js';
 import metricsExtended from './metrics_extended.js';
 import nodes from './nodes.js';
@@ -58,6 +59,9 @@ r.route('/balance/:address')
 
 r.route('/address/:address/transactions')
 .get(addressTransactions);
+
+r.route('/address/:address/stats')
+  .get(addressStats);
 
 r.route('/ai/list')
 .get(aiList);


### PR DESCRIPTION
## Summary
- provide `getAddressStats` helper in Blockchain
- expose new `/api/address/:address/stats` route
- document address stats endpoint and method in README
- add tests for the new helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68663e43754c832994f451042e534e3e
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a helper and API endpoint to show total sent, received, and transaction count for any address.

- **New Features**
  - Added getAddressStats helper to the Blockchain class.
  - Exposed GET /api/address/:address/stats endpoint.
  - Updated README and added tests for the new feature.

<!-- End of auto-generated description by cubic. -->

