### PR TITLE
Add WebAssembly contract engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ VM. The block is rejected if any script returns `false`. This allows simple
 conditions such as enforcing minimum payments or custom rules without a full
 virtual machine.
 
+For more advanced logic the chain now also accepts WebAssembly contracts. To
+use this, include an object `{ type: 'wasm', code: '<base64>' }` in the
+`script` field where `code` is a base64 encoded WebAssembly module exporting a
+`main` function that returns `1` on success. These modules run in a minimal
+environment, providing the transaction data through the `env` import object.
+
 ### API Endpoints
 
 The REST API exposes several helpers for querying the chain:

--- a/__tests__/script_engine.test.js
+++ b/__tests__/script_engine.test.js
@@ -18,4 +18,22 @@ describe('Transaction script validation', () => {
         bc.addBlock([tx], wallet);
         expect(bc.verifyChain()).toBe(false);
     });
+
+    test('valid wasm script keeps chain valid', () => {
+        const wasm = 'AGFzbQEAAAABBQFgAAF/AwIBAAcIAQRtYWluAAAKBgEEAEEBCw==';
+        const bc = new Blockchain();
+        const wallet = new Wallet(bc, 50);
+        const tx = Transaction.create(wallet, 'receiver', 10, { type: 'wasm', code: wasm });
+        bc.addBlock([tx], wallet);
+        expect(bc.verifyChain()).toBe(true);
+    });
+
+    test('failing wasm script invalidates chain', () => {
+        const wasm = 'AGFzbQEAAAABBQFgAAF/AwIBAAcIAQRtYWluAAAKBgEEAEEACw==';
+        const bc = new Blockchain();
+        const wallet = new Wallet(bc, 50);
+        const tx = Transaction.create(wallet, 'receiver', 10, { type: 'wasm', code: wasm });
+        bc.addBlock([tx], wallet);
+        expect(bc.verifyChain()).toBe(false);
+    });
 });

--- a/src/blockchain/modules/validator.js
+++ b/src/blockchain/modules/validator.js
@@ -1,5 +1,5 @@
 import Block from '../block.js';
-import { elliptic, runScript } from '../../modules/index.js';
+import { elliptic, runScript, runWasm } from '../../modules/index.js';
 
 export default(blockchain) => {
 	const [genesisBlock, ...blocks] = blockchain;
@@ -26,10 +26,15 @@ export default(blockchain) => {
                 }
 
                 if(Array.isArray(data)){
-                        for(const tx of data){
-                                if(tx.script){
-                                        const ok = runScript(tx.script, { tx });
-                                        if(!ok){
+                        for (const tx of data) {
+                                if (tx.script) {
+                                        let ok;
+                                        if (typeof tx.script === 'object' && tx.script.type === 'wasm') {
+                                                ok = runWasm(tx.script.code, { tx });
+                                        } else {
+                                                ok = runScript(tx.script, { tx });
+                                        }
+                                        if (!ok) {
                                                 throw Error('Script de transaccion invalido');
                                         }
                                 }

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -1,5 +1,6 @@
 import elliptic from './elliptic.js';
 import gnHash from './hash.js';
 import runScript from './scriptEngine.js';
+import runWasm from './wasmEngine.js';
 
-export { elliptic, gnHash, runScript };
+export { elliptic, gnHash, runScript, runWasm };

--- a/src/modules/wasmEngine.js
+++ b/src/modules/wasmEngine.js
@@ -1,0 +1,13 @@
+export default function runWasm(base64Code, context = {}) {
+    try {
+        const wasmBuffer = Buffer.from(base64Code, 'base64');
+        const module = new WebAssembly.Module(wasmBuffer);
+        const instance = new WebAssembly.Instance(module, { env: context });
+        const main = instance.exports.main;
+        if (typeof main !== 'function') return false;
+        return main() === 1;
+    } catch (err) {
+        console.error('WASM execution failed:', err);
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- implement WebAssembly runtime
- expose `runWasm` from module index
- allow validator to run WASM transaction scripts
- document WASM support in README
- test WASM script execution

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866406557788329835f744b9e33e8d3
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for WebAssembly contracts, allowing transaction scripts to run WASM modules for advanced validation.

- **New Features**
  - Added a WASM runtime and `runWasm` function.
  - Validator now accepts and runs WASM scripts in transactions.
  - Updated README with usage instructions.
  - Added tests for WASM script execution.

<!-- End of auto-generated description by cubic. -->

