### PR TITLE
Add real-time analytics page

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ blocks are created in real time.
 - Browse blocks in a table via the new **Blocks** section
 - Manage your wallet from the **Profile** page and submit metadata to the chain
 - Search for an address to view its balance and transactions
+- Monitor real-time analytics from the **Analytics** page
 
 ## Professional Overview
 

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { FaHome, FaCubes, FaUser, FaDatabase, FaTools } from 'react-icons/fa';
+import { FaHome, FaCubes, FaUser, FaDatabase, FaTools, FaChartLine } from 'react-icons/fa';
 import ThemeToggle from './ThemeToggle';
 
 export default function Layout({ children }) {
@@ -19,6 +19,9 @@ export default function Layout({ children }) {
             </Link>
             <Link href="/profile" className="hover:underline flex items-center gap-1">
               <FaUser /> Profile
+            </Link>
+            <Link href="/analytics" className="hover:underline flex items-center gap-1">
+              <FaChartLine /> Analytics
             </Link>
             <Link href="/admin" className="hover:underline flex items-center gap-1">
               <FaTools /> Admin

--- a/pages/analytics.js
+++ b/pages/analytics.js
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+const API_BASE = 'http://localhost:8000';
+
+export default function Analytics() {
+  const [stats, setStats] = useState(null);
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch(`${API_BASE}/api/metrics/extended`);
+      const json = await res.json();
+      setStats(json);
+    }
+    load();
+    const id = setInterval(load, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="py-6">
+      <h1 className="text-2xl font-bold mb-4">Network Analytics</h1>
+      <pre className="bg-gray-900 p-4 rounded overflow-auto">
+        {stats && JSON.stringify(stats, null, 2)}
+      </pre>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a new `/analytics` page that polls the `/api/metrics/extended` endpoint every 5 seconds
- expose Analytics link in navigation
- mention analytics page in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68664272791c83298c03d5c87538c9d1
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a real-time analytics page at /analytics that shows live network metrics and updates every 5 seconds.

- **New Features**
  - New Analytics page polls /api/metrics/extended for live stats.
  - Analytics link added to navigation.
  - README updated to mention the new page.

<!-- End of auto-generated description by cubic. -->

