### PR TITLE
Add token and NFT support

### DIFF
--- a/src/blockchain/blockchain.js
+++ b/src/blockchain/blockchain.js
@@ -103,11 +103,12 @@ class Blockchain {
                 return this.blocks.find((block) => block.hash === hash);
         }
 
-        getBalance(address){
+        getBalance(address, assetType = 'COIN'){
                 let balance = 0;
                 this.blocks.forEach(({data = []}) => {
                         if(Array.isArray(data)){
-                                data.forEach(({input, outputs}) => {
+                                data.forEach(({input, outputs, asset = { type: 'COIN' }}) => {
+                                        if((asset.type || 'COIN') !== assetType) return;
                                         outputs.forEach(({address: addr, amount}) => {
                                                 if(addr === address) balance += Number(amount);
                                         });


### PR DESCRIPTION
## Summary
- extend `Transaction` to include `asset` metadata and sign/verify changes
- update wallet operations for multi-asset transactions
- track balances by asset type in `Blockchain`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_686643423f488329ae605cd03e47e03c