### PR TITLE
Add placeholder for new dashboard

### DIFF
--- a/pages/bigdashboard.js
+++ b/pages/bigdashboard.js
@@ -1,0 +1,16 @@
+"use client"
+
+import { useState } from "react"
+import { Activity, Blocks, Network, Zap, ArrowLeft, Copy, ExternalLink, CheckCircle, Clock } from "lucide-react"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Progress } from "@/components/ui/progress"
+import { Search, Sun, Moon, TrendingUp, Fuel, Shield, Wallet, PieChart, Database, Code, FileText } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { Switch } from "@/components/ui/switch"
+import { Separator } from "@/components/ui/separator"
+
+export default function BYDChainDashboard(){return null}


### PR DESCRIPTION
## Summary
- add a placeholder page `bigdashboard.js` with imports for future dashboard features

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68664508bc748329aa192949a0cb7ecd