### PR TITLE
Add encrypted wallet key storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ storage/
 !storage/validators.json
 !src/storage/chain.json
 !src/storage/validators.json
+src/storage/wallets/

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ blocks are created in real time.
 - Search for a block by its hash
 - Browse blocks in a table via the new **Blocks** section
 - Manage your wallet from the **Profile** page and submit metadata to the chain
+- Export and import wallets using password‑encrypted keys
 - Search for an address to view its balance and transactions
 - Monitor real-time analytics from the **Analytics** page
 

--- a/__tests__/wallet_encryption.test.js
+++ b/__tests__/wallet_encryption.test.js
@@ -1,0 +1,12 @@
+import Blockchain from '../src/blockchain/index.js';
+import Wallet from '../src/wallet/index.js';
+
+describe('Wallet encrypted import/export', () => {
+  test('encrypted private key restores wallet', () => {
+    const bc = new Blockchain();
+    const w1 = new Wallet(bc, 50);
+    const enc = w1.exportEncrypted('testpass');
+    const w2 = Wallet.fromEncrypted(bc, enc, 'testpass', 50);
+    expect(w2.publicKey).toBe(w1.publicKey);
+  });
+});

--- a/src/middleware/Api/Endpoints/wallet_export.js
+++ b/src/middleware/Api/Endpoints/wallet_export.js
@@ -1,11 +1,15 @@
 import { wallets } from '../../../service/context.js';
 
 export default (req, res) => {
-    const { address } = req.body || {};
+    const { address, password } = req.body || {};
     const wallet = wallets.find(w => w.publicKey === address);
     if (!wallet) {
         res.json({ status: 0, error: 'Wallet not found' });
         return;
     }
-    res.json({ status: 'ok', mnemonic: wallet.exportMnemonic() });
+    if(password){
+        res.json({ status: 'ok', encrypted: wallet.exportEncrypted(password) });
+    } else {
+        res.json({ status: 'ok', mnemonic: wallet.exportMnemonic() });
+    }
 };

--- a/src/middleware/Api/Endpoints/wallet_import.js
+++ b/src/middleware/Api/Endpoints/wallet_import.js
@@ -2,13 +2,20 @@ import Wallet from '../../../wallet/index.js';
 import context, { blockchain, wallets } from '../../../service/context.js';
 
 export default (req, res) => {
-    const { mnemonic } = req.body || {};
+    const { mnemonic, encrypted, password, address } = req.body || {};
     try {
-        const wallet = Wallet.fromMnemonic(blockchain, mnemonic, 20);
+        let wallet;
+        if(encrypted && password){
+            wallet = Wallet.fromEncrypted(blockchain, encrypted, password, 20);
+        } else if(address && password){
+            wallet = Wallet.loadEncrypted(blockchain, address, password, 20);
+        } else {
+            wallet = Wallet.fromMnemonic(blockchain, mnemonic, 20);
+        }
         wallets.push(wallet);
         context.currentWallet = wallet;
         res.json({ status: 'ok', data: wallet.blockchainWallet() });
     } catch (err) {
-        res.json({ status: 0, error: 'Invalid mnemonic' });
+        res.json({ status: 0, error: 'Invalid wallet data' });
     }
 };

--- a/src/middleware/Api/Endpoints/wallet_new.js
+++ b/src/middleware/Api/Endpoints/wallet_new.js
@@ -4,7 +4,9 @@ import context, { blockchain, wallets } from '../../../service/context.js';
 export default (req, res) => {
         const { password } = req.body || {};
         const wallet = new Wallet(blockchain, 20);
-        wallet.password = password;
+        if(password){
+                wallet.saveEncrypted(password);
+        }
         context.currentWallet = wallet;
         wallets.push(wallet);
 


### PR DESCRIPTION
## Summary
- support encrypted wallet key export/import
- save encrypted keys to `src/storage/wallets`
- update wallet endpoints for encryption
- document password-encrypted wallet functionality
- ignore stored keys in git
- test encrypted wallet import/export

## Testing
- `npm run eslint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866477572c48329a2dd0f94ecfc12ac
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added password-encrypted wallet key export and import, with encrypted keys saved to disk for secure storage.

- **New Features**
  - Export and import wallets using encrypted keys and a password.
  - Store encrypted wallet keys in `src/storage/wallets` (ignored by git).
  - Updated wallet API endpoints to support encrypted key handling.
  - Added tests for encrypted wallet import/export.
  - Documented encrypted wallet usage in the README.

<!-- End of auto-generated description by cubic. -->

