### PR TITLE
Add validator and sanitize API payloads

### DIFF
--- a/src/middleware/Api/Endpoints/ai_store.js
+++ b/src/middleware/Api/Endpoints/ai_store.js
@@ -1,8 +1,19 @@
 
 import { blockchain, walletMiner, p2pAction } from '../../../service/context.js';
+import Joi from '../../../utils/validator.js';
+
+const schema = Joi.object({
+    model: Joi.string().required(),
+    description: Joi.string().required(),
+    dataHash: Joi.string().required()
+});
 
 export default (req, res) => {
-    const { model, description, dataHash } = req.body;
+    const { error, value } = schema.validate(req.body || {});
+    if (error) {
+        return res.status(400).json({ status: 0, error });
+    }
+    const { model, description, dataHash } = value;
     try {
         const block = blockchain.addBlock(
             { type: 'AI_DATA', model, description, hash: dataHash },

--- a/src/middleware/Api/Endpoints/mine.js
+++ b/src/middleware/Api/Endpoints/mine.js
@@ -1,14 +1,23 @@
 import { blockchain, walletMiner, p2pAction } from '../../../service/context.js';
+import Joi from '../../../utils/validator.js';
+
+const schema = Joi.object({
+        data: Joi.string().required()
+});
 
 export default (req, res) => {
 
-        const { 'body': {data} } = req;
-        const block = blockchain.addBlock(data, walletMiner);
+        const { error, value } = schema.validate(req.body || {});
+        if (error) {
+                return res.status(400).json({ status: 0, error });
+        }
+
+        const block = blockchain.addBlock(value.data, walletMiner);
         p2pAction.sync();
- 	
- 	res.json({
- 		'blocks': blockchain.blocks.length,
- 		block
- 	});
+
+        res.json({
+                'blocks': blockchain.blocks.length,
+                block
+        });
 
 };

--- a/src/middleware/Api/Endpoints/transactions_new.js
+++ b/src/middleware/Api/Endpoints/transactions_new.js
@@ -1,15 +1,26 @@
 import { MESSAGE } from '../../../service/p2p.js';
 import { currentWallet, p2pAction } from '../../../service/context.js';
+import Joi from '../../../utils/validator.js';
+
+const schema = Joi.object({
+    recipient: Joi.string().hex().required(),
+    amount: Joi.number().positive().required(),
+    script: Joi.string().allow('', null)
+});
 
 export default (req, res) => {
-        const { recipient, amount, script } = req.body || {};
+        const { error, value } = schema.validate(req.body || {});
+        if (error) {
+                return res.status(400).json({ status: 0, error });
+        }
+        const { recipient, amount, script } = value;
 
         if(!currentWallet){
                 return res.status(400).json({ error: 'No hay una wallet activa' });
         }
 
         try{
-                const tr = currentWallet.createTransaction(recipient, Number(amount), script);
+                const tr = currentWallet.createTransaction(recipient.trim(), amount, script);
                 p2pAction.broadcast(MESSAGE.TR, tr);
                 res.json(tr);
         }catch(error){

--- a/src/middleware/Api/Endpoints/wallet_access.js
+++ b/src/middleware/Api/Endpoints/wallet_access.js
@@ -1,8 +1,18 @@
 import { currentWallet } from '../../../service/context.js';
+import Joi from '../../../utils/validator.js';
+
+const schema = Joi.object({
+        private: Joi.string().required()
+});
 
 export default (req, res) => {
 
-        const my_wallet = currentWallet.sign(req.body.private);
+        const { error, value } = schema.validate(req.body || {});
+        if (error) {
+                return res.status(400).json({ status: 0, error });
+        }
+
+        const my_wallet = currentWallet.sign(value.private);
 
         console.log(my_wallet);
 

--- a/src/middleware/Api/Endpoints/wallet_export.js
+++ b/src/middleware/Api/Endpoints/wallet_export.js
@@ -1,11 +1,20 @@
 import { wallets } from '../../../service/context.js';
+import Joi from '../../../utils/validator.js';
+
+const schema = Joi.object({
+    address: Joi.string().hex().required(),
+    password: Joi.string().allow('', null)
+});
 
 export default (req, res) => {
-    const { address, password } = req.body || {};
+    const { error, value } = schema.validate(req.body || {});
+    if (error) {
+        return res.status(400).json({ status: 0, error });
+    }
+    const { address, password } = value;
     const wallet = wallets.find(w => w.publicKey === address);
     if (!wallet) {
-        res.json({ status: 0, error: 'Wallet not found' });
-        return;
+        return res.json({ status: 0, error: 'Wallet not found' });
     }
     if(password){
         res.json({ status: 'ok', encrypted: wallet.exportEncrypted(password) });

--- a/src/middleware/Api/Endpoints/wallet_import.js
+++ b/src/middleware/Api/Endpoints/wallet_import.js
@@ -1,16 +1,30 @@
 import Wallet from '../../../wallet/index.js';
 import context, { blockchain, wallets } from '../../../service/context.js';
+import Joi from '../../../utils/validator.js';
+
+const schema = Joi.object({
+    mnemonic: Joi.string().allow('', null),
+    encrypted: Joi.string().allow('', null),
+    password: Joi.string().allow('', null),
+    address: Joi.string().hex().allow('', null)
+});
 
 export default (req, res) => {
-    const { mnemonic, encrypted, password, address } = req.body || {};
+    const { error, value } = schema.validate(req.body || {});
+    if (error) {
+        return res.status(400).json({ status: 0, error });
+    }
+    const { mnemonic, encrypted, password, address } = value;
     try {
         let wallet;
         if(encrypted && password){
             wallet = Wallet.fromEncrypted(blockchain, encrypted, password, 20);
         } else if(address && password){
             wallet = Wallet.loadEncrypted(blockchain, address, password, 20);
-        } else {
+        } else if(mnemonic){
             wallet = Wallet.fromMnemonic(blockchain, mnemonic, 20);
+        } else {
+            return res.status(400).json({ status: 0, error: 'Wallet data missing' });
         }
         wallets.push(wallet);
         context.currentWallet = wallet;

--- a/src/middleware/Api/Endpoints/wallet_new.js
+++ b/src/middleware/Api/Endpoints/wallet_new.js
@@ -1,8 +1,18 @@
 import Wallet from '../../../wallet/index.js';
 import context, { blockchain, wallets } from '../../../service/context.js';
+import Joi from '../../../utils/validator.js';
+
+const schema = Joi.object({
+        password: Joi.string().allow('', null)
+});
 
 export default (req, res) => {
-        const { password } = req.body || {};
+        const { error, value } = schema.validate(req.body || {});
+        if (error) {
+                return res.status(400).json({ status: 0, error });
+        }
+        const { password } = value;
+
         const wallet = new Wallet(blockchain, 20);
         if(password){
                 wallet.saveEncrypted(password);

--- a/src/middleware/Api/Endpoints/wallet_stake.js
+++ b/src/middleware/Api/Endpoints/wallet_stake.js
@@ -2,12 +2,21 @@
 
 
 import { currentWallet } from '../../../service/context.js';
+import Joi from '../../../utils/validator.js';
+
+const schema = Joi.object({
+    amount: Joi.number().positive().required()
+});
 
 export default (req, res) => {
 
-    const { body: { amount } } = req;
+    const { error, value } = schema.validate(req.body || {});
+    if (error) {
+        return res.status(400).json({ status: 0, error });
+    }
+
     try {
-        currentWallet.stake(Number(amount));
+        currentWallet.stake(value.amount);
         res.json({ status: 'ok', stake: currentWallet.stakeBalance });
     } catch (error) {
         res.json({ status: 0, error: error.message });

--- a/src/utils/validator.js
+++ b/src/utils/validator.js
@@ -1,0 +1,56 @@
+class BaseSchema {
+  constructor(type) {
+    this.type = type;
+    this._required = false;
+    this._hex = false;
+    this._positive = false;
+    this._allow = [];
+  }
+  required() { this._required = true; return this; }
+  hex() { this._hex = true; return this; }
+  positive() { this._positive = true; return this; }
+  allow(...values) { this._allow.push(...values); return this; }
+  _validateString(value, key) {
+    if (typeof value !== 'string') return `${key} must be a string`;
+    if (this._hex && !/^[0-9a-fA-F]+$/.test(value)) return `${key} must be a hex string`;
+    return null;
+  }
+  _validateNumber(value, key) {
+    const num = Number(value);
+    if (!Number.isFinite(num)) return `${key} must be a number`;
+    if (this._positive && num <= 0) return `${key} must be positive`;
+    return null;
+  }
+  validate(value, key) {
+    if (value === undefined || value === null || value === '') {
+      if (this._required && !this._allow.includes(value)) {
+        return { error: `${key} is required` };
+      }
+      return { value };
+    }
+    let err;
+    if (this.type === 'string') err = this._validateString(value, key);
+    if (this.type === 'number') err = this._validateNumber(value, key);
+    if (err) return { error: err };
+    if (this.type === 'number') value = Number(value);
+    return { value };
+  }
+}
+
+function string() { return new BaseSchema('string'); }
+function number() { return new BaseSchema('number'); }
+function object(schema) {
+  return {
+    validate(data = {}) {
+      const result = {};
+      for (const key of Object.keys(schema)) {
+        const { error, value } = schema[key].validate(data[key], key);
+        if (error) return { error };
+        result[key] = value;
+      }
+      return { value: result };
+    }
+  };
+}
+
+export default { string, number, object };


### PR DESCRIPTION
## Summary
- introduce a small Joi-like validator utility
- validate request bodies for API endpoints
- sanitize amounts, addresses and script fields before creating transactions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866495a048083298c58625e3b2ad9e8