### PR TITLE
Add live metrics streaming and charts

### DIFF
--- a/__tests__/metrics_module.test.js
+++ b/__tests__/metrics_module.test.js
@@ -1,0 +1,24 @@
+import Blockchain from '../src/blockchain/index.js';
+import Wallet from '../src/wallet/index.js';
+import Metrics from '../src/service/metrics.js';
+
+describe('Metrics module', () => {
+  test('gather returns mempool size and node count', () => {
+    const bc = new Blockchain();
+    const fakeP2P = { sockets: [1, 2] };
+    const metrics = new Metrics(bc, fakeP2P);
+    const data = metrics.gather();
+    expect(data.mempoolSize).toBe(0);
+    expect(data.connectedNodes).toBe(2);
+  });
+
+  test('block time updates after new block', () => {
+    const bc = new Blockchain();
+    const fakeP2P = { sockets: [] };
+    const metrics = new Metrics(bc, fakeP2P);
+    const w = new Wallet(bc, 0);
+    bc.addBlock('data', w);
+    const data = metrics.gather();
+    expect(typeof data.blockTime).toBe('number');
+  });
+});

--- a/pages/analytics.js
+++ b/pages/analytics.js
@@ -1,27 +1,55 @@
 import { useEffect, useState } from 'react';
 
-const API_BASE = 'http://localhost:8000';
+const API_BASE = 'ws://localhost:8000';
+
+function LineChart({ data, color }) {
+  if (data.length === 0) return <svg className="w-full h-32" />;
+  const max = Math.max(...data, 1);
+  const points = data
+    .map((v, i) => {
+      const x = (i / (data.length - 1)) * 100;
+      const y = 100 - (v / max) * 100;
+      return `${x},${y}`;
+    })
+    .join(' ');
+  return (
+    <svg viewBox="0 0 100 100" className="w-full h-32">
+      <polyline fill="none" stroke={color} strokeWidth="2" points={points} />
+    </svg>
+  );
+}
 
 export default function Analytics() {
-  const [stats, setStats] = useState(null);
+  const [blockTimes, setBlockTimes] = useState([]);
+  const [mempoolSizes, setMempoolSizes] = useState([]);
+  const [nodes, setNodes] = useState([]);
 
   useEffect(() => {
-    async function load() {
-      const res = await fetch(`${API_BASE}/api/metrics/extended`);
-      const json = await res.json();
-      setStats(json);
-    }
-    load();
-    const id = setInterval(load, 5000);
-    return () => clearInterval(id);
+    const ws = new WebSocket(`${API_BASE}/api/metrics/live`);
+    ws.onmessage = (ev) => {
+      const data = JSON.parse(ev.data);
+      setBlockTimes((b) => [...b.slice(-19), data.blockTime]);
+      setMempoolSizes((m) => [...m.slice(-19), data.mempoolSize]);
+      setNodes((n) => [...n.slice(-19), data.connectedNodes]);
+    };
+    return () => ws.close();
   }, []);
 
   return (
-    <div className="py-6">
+    <div className="py-6 space-y-6">
       <h1 className="text-2xl font-bold mb-4">Network Analytics</h1>
-      <pre className="bg-gray-900 p-4 rounded overflow-auto">
-        {stats && JSON.stringify(stats, null, 2)}
-      </pre>
+      <div>
+        <h2 className="font-semibold">Block Time</h2>
+        <LineChart data={blockTimes} color="skyblue" />
+      </div>
+      <div>
+        <h2 className="font-semibold">Mempool Size</h2>
+        <LineChart data={mempoolSizes} color="orange" />
+      </div>
+      <div>
+        <h2 className="font-semibold">Connected Nodes</h2>
+        <LineChart data={nodes} color="limegreen" />
+      </div>
     </div>
   );
 }

--- a/src/service/index.js
+++ b/src/service/index.js
@@ -2,10 +2,12 @@ import express from 'express';
 import bodyParser from 'body-parser';
 import context from './context.js';
 import middleware from '../middleware/index.js';
+import Metrics from './metrics.js';
 
 
 const app = express();
 const { PORT = 8000 } = process.env;
+const metrics = new Metrics(context.blockchain, context.p2pAction);
 
 
 app.use(bodyParser.json());
@@ -21,6 +23,7 @@ app.use((req, res, next) => {
 });
 middleware(app);
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
         context.p2pAction.listen();
+        metrics.listen(server);
 });

--- a/src/service/metrics.js
+++ b/src/service/metrics.js
@@ -1,0 +1,41 @@
+import WebSocket from 'ws';
+
+class Metrics {
+  constructor(blockchain, p2pAction) {
+    this.blockchain = blockchain;
+    this.p2pAction = p2pAction;
+    this.wss = null;
+    this.lastTimestamp = blockchain.getLatestBlock().timestamp;
+  }
+
+  gather() {
+    const mempoolSize = this.blockchain.memoryPool.transactions.length;
+    const connectedNodes = this.p2pAction.sockets.length;
+    let blockTime = 0;
+    const latest = this.blockchain.getLatestBlock();
+    if (latest) {
+      blockTime = latest.timestamp - this.lastTimestamp;
+      if (blockTime !== 0) {
+        this.lastTimestamp = latest.timestamp;
+      }
+    }
+    return { blockTime, mempoolSize, connectedNodes };
+  }
+
+  listen(server) {
+    this.wss = new WebSocket.Server({ server, path: '/api/metrics/live' });
+    this.wss.on('connection', (ws) => {
+      const send = () => {
+        const data = this.gather();
+        ws.send(JSON.stringify(data));
+      };
+      send();
+      const id = setInterval(() => {
+        if (ws.readyState === WebSocket.OPEN) send();
+      }, 1000);
+      ws.on('close', () => clearInterval(id));
+    });
+  }
+}
+
+export default Metrics;


### PR DESCRIPTION
## Summary
- create `Metrics` service for block time, mempool size and node connections
- expose `/api/metrics/live` websocket via the metrics service
- render real-time charts on the Analytics page
- test the new Metrics module

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68664b4ce54c832985bb389e67d8a9b4
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added live metrics streaming with a new WebSocket API and real-time charts on the Analytics page.

- **New Features**
  - Created a Metrics service to track block time, mempool size, and connected nodes.
  - Exposed `/api/metrics/live` WebSocket endpoint for live metric updates.
  - Updated Analytics page to show real-time charts for all metrics.
  - Added tests for the Metrics module.

<!-- End of auto-generated description by cubic. -->

