### PR TITLE
Add wallet connection modal and profile export

### DIFF
--- a/components/ConnectWalletModal.tsx
+++ b/components/ConnectWalletModal.tsx
@@ -1,0 +1,32 @@
+import Modal from './Modal'
+import { useWallet } from './WalletContext'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+export default function ConnectWalletModal({ open, onClose }: Props) {
+  const { createWallet } = useWallet()
+
+  async function handleAccept() {
+    await createWallet()
+    onClose()
+  }
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <h2 className="text-xl font-semibold mb-4">Términos de Uso</h2>
+      <p className="mb-4 text-sm">
+        Al continuar confirma que acepta los términos y condiciones del uso de la
+        aplicación.
+      </p>
+      <button
+        onClick={handleAccept}
+        className="px-4 py-2 bg-blue-500 text-white rounded"
+      >
+        Aceptar y Firmar
+      </button>
+    </Modal>
+  )
+}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,12 +1,14 @@
-import { ReactNode } from 'react'
+import { ReactNode, useState } from 'react'
 import { Blocks, Search as SearchIcon, Sun, Moon, Network } from 'lucide-react'
 import { Button } from './ui/button'
 import { Badge } from './ui/badge'
 import { Switch } from './ui/switch'
 import { useTheme } from './ThemeContext'
+import ConnectWalletModal from './ConnectWalletModal'
 
 export default function Layout({ children }: { children: ReactNode }) {
   const { theme, setTheme } = useTheme()
+  const [modal, setModal] = useState(false)
   return (
     <div className="min-h-screen bg-background text-foreground">
       <header className="border-b bg-card shadow-sm">
@@ -46,7 +48,11 @@ export default function Layout({ children }: { children: ReactNode }) {
               <div className="text-sm text-muted-foreground">
                 Block Height: <span className="font-mono font-semibold">1,247,892</span>
               </div>
-              <Button variant="outline" className="gap-2">
+              <Button
+                variant="outline"
+                className="gap-2"
+                onClick={() => setModal(true)}
+              >
                 <Network className="w-4 h-4" />
                 Connect Wallet
               </Button>
@@ -55,6 +61,7 @@ export default function Layout({ children }: { children: ReactNode }) {
         </div>
       </header>
       <main className="container mx-auto px-4 py-6">{children}</main>
+      <ConnectWalletModal open={modal} onClose={() => setModal(false)} />
     </div>
   )
 }

--- a/components/WalletContext.tsx
+++ b/components/WalletContext.tsx
@@ -1,0 +1,72 @@
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
+
+export type Wallet = {
+  publicKey: string
+  balance: number
+}
+
+interface WalletContextType {
+  wallet: Wallet | null
+  createWallet: () => Promise<void>
+  exportMnemonic: () => Promise<string | null>
+  refreshBalance: () => Promise<number | null>
+}
+
+const WalletContext = createContext<WalletContextType | undefined>(undefined)
+
+const API_BASE = 'http://localhost:8000'
+
+export function WalletProvider({ children }: { children: ReactNode }) {
+  const [wallet, setWallet] = useState<Wallet | null>(null)
+
+  useEffect(() => {
+    const stored = localStorage.getItem('wallet')
+    if (stored) setWallet(JSON.parse(stored))
+  }, [])
+
+  useEffect(() => {
+    if (wallet) localStorage.setItem('wallet', JSON.stringify(wallet))
+    else localStorage.removeItem('wallet')
+  }, [wallet])
+
+  async function createWallet() {
+    const res = await fetch(`${API_BASE}/api/wallet/new`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({})
+    })
+    const json = await res.json()
+    if (json.data) setWallet(json.data)
+  }
+
+  async function exportMnemonic() {
+    if (!wallet) return null
+    const res = await fetch(`${API_BASE}/api/wallet/export`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ address: wallet.publicKey })
+    })
+    const json = await res.json()
+    return json.mnemonic || null
+  }
+
+  async function refreshBalance() {
+    if (!wallet) return null
+    const res = await fetch(`${API_BASE}/api/balance/${wallet.publicKey}`)
+    const json = await res.json()
+    setWallet({ ...wallet, balance: json.balance })
+    return json.balance
+  }
+
+  return (
+    <WalletContext.Provider value={{ wallet, createWallet, exportMnemonic, refreshBalance }}>
+      {children}
+    </WalletContext.Provider>
+  )
+}
+
+export function useWallet() {
+  const ctx = useContext(WalletContext)
+  if (!ctx) throw new Error('WalletContext not found')
+  return ctx
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,13 +1,16 @@
 import type { AppProps } from 'next/app';
 import Layout from '../components/Layout';
 import { ThemeProvider } from '../components/ThemeContext';
+import { WalletProvider } from '../components/WalletContext';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider>
-      <Layout>
-        <Component {...pageProps} />
-      </Layout>
+      <WalletProvider>
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
+      </WalletProvider>
     </ThemeProvider>
   );
 }

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,124 +1,47 @@
-import { useState, useEffect } from 'react';
-
-const API_BASE = 'http://localhost:8000';
+import { useEffect, useState } from 'react'
+import { useWallet } from '../components/WalletContext'
 
 export default function Profile() {
-  const [password, setPassword] = useState('');
-  const [mnemonic, setMnemonic] = useState('');
-  const [wallets, setWallets] = useState([]);
-  const [selected, setSelected] = useState(null);
-  const [transactions, setTransactions] = useState([]);
+  const { wallet, exportMnemonic, refreshBalance } = useWallet()
+  const [mnemonic, setMnemonic] = useState<string | null>(null)
 
-  async function loadWallets() {
-    const res = await fetch(`${API_BASE}/api/wallet/list`);
-    const json = await res.json();
-    setWallets(json);
+  useEffect(() => {
+    if (wallet) refreshBalance()
+  }, [wallet, refreshBalance])
+
+  async function handleExport() {
+    const m = await exportMnemonic()
+    setMnemonic(m)
   }
 
-  useEffect(() => { loadWallets(); }, []);
-
-  async function createWallet() {
-    await fetch(`${API_BASE}/api/wallet/new`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ password })
-    });
-    setPassword('');
-    loadWallets();
-  }
-
-  async function importWallet() {
-    await fetch(`${API_BASE}/api/wallet/import`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ mnemonic })
-    });
-    setMnemonic('');
-    loadWallets();
-  }
-
-  async function exportWallet(address) {
-    const res = await fetch(`${API_BASE}/api/wallet/export`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ address })
-    });
-    const json = await res.json();
-    if (json.mnemonic) alert(json.mnemonic);
-  }
-
-  async function selectWallet(address) {
-    setSelected(address);
-    const res = await fetch(`${API_BASE}/api/address/${address}/transactions`);
-    const json = await res.json();
-    setTransactions(json);
+  if (!wallet) {
+    return <div className="py-6">No wallet connected.</div>
   }
 
   return (
-    <div className="max-w-xl mx-auto py-6">
-      <h1 className="text-2xl font-bold mb-4 flex items-center gap-2">
-        Wallets
-      </h1>
-      <div className="flex flex-col gap-2 mb-4">
-        <input
-          type="password"
-          value={password}
-          onChange={e => setPassword(e.target.value)}
-          placeholder="password"
-          className="border p-2 rounded bg-gray-900 text-gray-100"
-        />
+    <div className="max-w-xl mx-auto py-6 space-y-4">
+      <h1 className="text-2xl font-bold">Profile</h1>
+      <div className="bg-black border border-gray-700 p-4 rounded space-y-2">
+        <div>
+          <span className="font-semibold">Public Key:</span>
+          <span className="ml-2 break-all">{wallet.publicKey}</span>
+        </div>
+        <div>
+          <span className="font-semibold">Balance:</span>
+          <span className="ml-2">{wallet.balance}</span>
+        </div>
+      </div>
+      <div className="space-x-2">
         <button
-          onClick={createWallet}
-          className="px-4 py-2 bg-blue-500 text-white rounded"
+          onClick={handleExport}
+          className="px-4 py-2 bg-indigo-500 text-white rounded"
         >
-          Create
+          Export Keys
         </button>
       </div>
-
-      <div className="flex flex-col gap-2 mb-6">
-        <input
-          value={mnemonic}
-          onChange={e => setMnemonic(e.target.value)}
-          placeholder="mnemonic"
-          className="border p-2 rounded bg-gray-900 text-gray-100"
-        />
-        <button
-          onClick={importWallet}
-          className="px-4 py-2 bg-blue-500 text-white rounded"
-        >
-          Import
-        </button>
-      </div>
-
-      <section className="mb-6">
-        <h2 className="text-xl font-semibold mb-2">My Wallets</h2>
-        {wallets.map(w => (
-          <div key={w.publicKey} className="bg-black border border-gray-700 p-3 rounded mb-2 flex items-center gap-2">
-            <button
-              onClick={() => selectWallet(w.publicKey)}
-              className="px-2 py-1 bg-green-500 text-white rounded"
-            >
-              Select
-            </button>
-            <button
-              onClick={() => exportWallet(w.publicKey)}
-              className="px-2 py-1 bg-indigo-500 text-white rounded"
-            >
-              Export
-            </button>
-            <span className="ml-2 break-all">{w.publicKey}</span>
-          </div>
-        ))}
-      </section>
-
-      {selected && (
-        <section>
-          <h2 className="text-xl font-semibold mb-2">Transactions</h2>
-          <pre className="bg-gray-900 p-4 rounded overflow-auto">
-            {JSON.stringify(transactions, null, 2)}
-          </pre>
-        </section>
+      {mnemonic && (
+        <pre className="bg-gray-900 p-3 rounded break-all">{mnemonic}</pre>
       )}
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- enable wallet context for storing connected wallet details
- add modal to connect a wallet after accepting terms
- integrate wallet modal in site layout
- wrap app with `WalletProvider`
- replace profile page with export and balance view

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866591ee80c83299e151bf617bbd8e5
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a wallet connection modal and updated the profile page to show wallet balance and allow key export.

- **New Features**
  - Added modal for connecting a wallet after accepting terms.
  - Created wallet context to store wallet details and actions.
  - Updated profile page to show public key, balance, and export option.

<!-- End of auto-generated description by cubic. -->

