### PR TITLE
Implement dynamic BYDChain dashboard

### DIFF
--- a/pages/bigdashboard.tsx
+++ b/pages/bigdashboard.tsx
@@ -1,16 +1,150 @@
 "use client"
 
-import { useState } from "react"
-import { Activity, Blocks, Network, Zap, ArrowLeft, Copy, ExternalLink, CheckCircle, Clock } from "lucide-react"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
+import { useEffect, useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Progress } from "@/components/ui/progress"
-import { Search, Sun, Moon, TrendingUp, Fuel, Shield, Wallet, PieChart, Database, Code, FileText } from "lucide-react"
-import { Input } from "@/components/ui/input"
-import { Switch } from "@/components/ui/switch"
-import { Separator } from "@/components/ui/separator"
 
-export default function BYDChainDashboard(){return null}
+const API_BASE = "http://localhost:8000"
+
+interface Stats {
+  chainLength: number
+  totalTransactions: number
+  avgBlockTime: number
+  totalStake: number
+  mempoolSize: number
+  uniqueAddresses: number
+}
+
+interface BlockData {
+  hash: string
+  validator: string
+  timestamp: number
+  data: any
+}
+
+interface ValidatorEntry { address: string; stake: number }
+
+export default function BYDChainDashboard() {
+  const [stats, setStats] = useState<Stats | null>(null)
+  const [blocks, setBlocks] = useState<BlockData[]>([])
+  const [validators, setValidators] = useState<ValidatorEntry[]>([])
+  const [mempool, setMempool] = useState<any[]>([])
+
+  useEffect(() => {
+    fetch(`${API_BASE}/api/metrics/extended`).then(r => r.json()).then(setStats).catch(console.error)
+    fetch(`${API_BASE}/api/blocks`).then(r => r.json()).then(data => {
+      if(Array.isArray(data)) setBlocks(data.slice(-5).reverse())
+    }).catch(console.error)
+    fetch(`${API_BASE}/api/validators`).then(r => r.json()).then(v => {
+      if(v && typeof v === 'object'){
+        setValidators(Object.entries(v).map(([address, stake]) => ({ address, stake: Number(stake) })))
+      }
+    }).catch(console.error)
+    fetch(`${API_BASE}/api/mempool`).then(r => r.json()).then(setMempool).catch(console.error)
+  }, [])
+
+  if(!stats) return <p>Loading...</p>
+
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold">BYDChain Dashboard</h1>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Card>
+          <CardHeader><CardTitle>Total Blocks</CardTitle></CardHeader>
+          <CardContent>{stats.chainLength}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader><CardTitle>Total Transactions</CardTitle></CardHeader>
+          <CardContent>{stats.totalTransactions}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader><CardTitle>Mempool Size</CardTitle></CardHeader>
+          <CardContent>{stats.mempoolSize}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader><CardTitle>Average Block Time</CardTitle></CardHeader>
+          <CardContent>{stats.avgBlockTime.toFixed(2)} ms</CardContent>
+        </Card>
+        <Card>
+          <CardHeader><CardTitle>Total Stake</CardTitle></CardHeader>
+          <CardContent>{stats.totalStake}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader><CardTitle>Unique Addresses</CardTitle></CardHeader>
+          <CardContent>{stats.uniqueAddresses}</CardContent>
+        </Card>
+      </div>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Latest Blocks</h2>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Hash</TableHead>
+              <TableHead>Validator</TableHead>
+              <TableHead>Time</TableHead>
+              <TableHead>Transactions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {blocks.map(b => (
+              <TableRow key={b.hash}>
+                <TableCell className="font-mono text-sm">{b.hash.slice(0,12)}...</TableCell>
+                <TableCell className="font-mono text-sm">{b.validator}</TableCell>
+                <TableCell>{new Date(b.timestamp).toLocaleString()}</TableCell>
+                <TableCell>{Array.isArray(b.data) ? b.data.length : 1}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Validators</h2>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Address</TableHead>
+              <TableHead>Stake</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {validators.map(v => (
+              <TableRow key={v.address}>
+                <TableCell className="font-mono text-sm">{v.address}</TableCell>
+                <TableCell>{v.stake}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Pending Transactions</h2>
+        {mempool.length === 0 ? (
+          <p>No pending transactions</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>From</TableHead>
+                <TableHead>To</TableHead>
+                <TableHead>Amount</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {mempool.map((tx, idx) => (
+                <TableRow key={idx}>
+                  <TableCell className="font-mono text-sm">{tx.input.address}</TableCell>
+                  <TableCell className="font-mono text-sm">{tx.outputs[0].address}</TableCell>
+                  <TableCell>{tx.outputs[0].amount}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- show real blockchain information in `pages/bigdashboard.tsx`
- fetch metrics, blocks, validators and mempool data from the API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68665a2d59ac83299f816b80bccf740c
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a dynamic BYDChain dashboard that displays real blockchain data, including metrics, recent blocks, validators, and pending transactions.

- **New Features**
  - Fetches and shows live metrics, latest blocks, validator list, and mempool data from the API.

<!-- End of auto-generated description by cubic. -->

