### PR TITLE
Add CLI tool

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import walletNew from '../src/middleware/Api/Endpoints/wallet_new.js';
+import walletImport from '../src/middleware/Api/Endpoints/wallet_import.js';
+import walletExport from '../src/middleware/Api/Endpoints/wallet_export.js';
+import walletList from '../src/middleware/Api/Endpoints/wallet_list.js';
+import walletStake from '../src/middleware/Api/Endpoints/wallet_stake.js';
+import transactionsNew from '../src/middleware/Api/Endpoints/transactions_new.js';
+import '../src/service/context.js';
+
+function runEndpoint(handler, body = {}) {
+  const req = { body };
+  const res = {
+    statusCode: 200,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data) {
+      console.log(JSON.stringify(data, null, 2));
+    }
+  };
+  handler(req, res);
+}
+
+const program = new Command();
+program
+  .option('--api <port>', 'Puerto API')
+  .option('--p2p-port <port>', 'Puerto P2P')
+  .option('--tls-key <path>', 'Ruta clave TLS')
+  .option('--tls-cert <path>', 'Ruta certificado TLS');
+
+program
+  .command('start')
+  .description('Arranca el nodo')
+  .action(() => {
+    const opts = program.opts();
+    if (opts.api) process.env.PORT = opts.api;
+    if (opts.p2pPort) process.env.P2P_PORT = opts.p2pPort;
+    if (opts.tlsKey) process.env.WSS_KEY_PATH = opts.tlsKey;
+    if (opts.tlsCert) process.env.WSS_CERT_PATH = opts.tlsCert;
+    import('../src/service/index.js');
+  });
+
+const wallet = program.command('wallet').description('Operaciones de wallet');
+
+wallet
+  .command('new')
+  .option('-p, --password <password>', 'Contraseña para encriptar')
+  .action((opts) => {
+    runEndpoint(walletNew, { password: opts.password });
+  });
+
+wallet
+  .command('import')
+  .option('-m, --mnemonic <mnemonic>')
+  .option('-e, --encrypted <encrypted>')
+  .option('-p, --password <password>')
+  .option('-a, --address <address>')
+  .action((opts) => {
+    runEndpoint(walletImport, opts);
+  });
+
+wallet
+  .command('export')
+  .option('-a, --address <address>')
+  .option('-p, --password <password>')
+  .action((opts) => {
+    runEndpoint(walletExport, opts);
+  });
+
+wallet
+  .command('list')
+  .action(() => {
+    runEndpoint(walletList, {});
+  });
+
+program
+  .command('stake <amount>')
+  .description('Aportar stake')
+  .action((amount) => {
+    runEndpoint(walletStake, { amount: Number(amount) });
+  });
+
+program
+  .command('send <recipient> <amount>')
+  .option('-s, --script <script>')
+  .description('Enviar transacción')
+  .action((recipient, amount, opts) => {
+    runEndpoint(transactionsNew, { recipient, amount: Number(amount), script: opts.script });
+  });
+
+program.parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:watch": "jest --watchAll",
     "build": "next build && next export",
     "desktop:win": "electron-builder --win",
-    "desktop:mac": "electron-builder --mac"
+    "desktop:mac": "electron-builder --mac",
+    "cli": "node ./bin/cli.js"
   },
   "build": {
     "files": ["out", "main.js", "src/**/*"]
@@ -61,7 +62,8 @@
     "react-tooltip": "^5.11.0",
     "react-loading-skeleton": "^3.3.1",
     "bip39": "^3.0.4",
-    "bip32": "^2.0.6"
+    "bip32": "^2.0.6",
+    "commander": "^10.0.0"
   },
   "jest": {
     "silent": false,


### PR DESCRIPTION
## Summary
- add command line interface under `bin/cli.js`
- register `cli` npm script
- include commander dependency for CLI

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68665c0c287483298c7a3e682efddf45