### PR TITLE
Add DB adapters and env docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,18 @@ the `DB_TYPE` environment variable and connection details in
 `src/config/database.js`. Supported types include **mongodb**, **mysql**,
 **postgres** and **firebase**.
 
+### Environment Variables
+
+The database adapter is controlled through the following variables:
+
+- `DB_TYPE` selects the backend. Use `json` for local files or one of
+  `mongodb`, `mysql`, `postgres` or `firebase` to store data remotely.
+- `DB_URI` sets the connection string or database URL.
+- `DB_USER` and `DB_PASSWORD` provide credentials for MySQL and PostgreSQL.
+- `FIREBASE_CERT` should point to the Firebase service account JSON file.
+
+If no variables are supplied the node defaults to the local JSON backend.
+
 ### Mining Transactions
 
 Pending transfers remain in the mempool until a block is produced. You can

--- a/src/config/database.js
+++ b/src/config/database.js
@@ -1,4 +1,8 @@
 import fs from 'fs';
+import { MongoClient } from 'mongodb';
+import mysql from 'mysql2/promise';
+import { Client as PgClient } from 'pg';
+import admin from 'firebase-admin';
 
 /**
  * Simple database configuration module.
@@ -6,8 +10,8 @@ import fs from 'fs';
  * Supported types: json (default), mongodb, mysql, postgres, firebase.
  * Connection parameters are read from DB_URI, DB_USER, DB_PASSWORD and FIREBASE_CERT.
  *
- * Only the JSON backend is implemented synchronously. Other backends require
- * additional libraries and should be implemented as needed.
+ * The JSON backend uses local files. MongoDB, MySQL, PostgreSQL and Firebase
+ * rely on their official Node.js drivers and operate asynchronously.
  */
 
 export const DB_TYPE = process.env.DB_TYPE || 'json';
@@ -17,6 +21,7 @@ export const DB_PASSWORD = process.env.DB_PASSWORD || '';
 export const FIREBASE_CERT = process.env.FIREBASE_CERT || '';
 
 let client = null;
+let collection = null;
 
 export function getDbType() {
   return DB_TYPE;
@@ -26,14 +31,37 @@ export function getDbType() {
  * Placeholder connect function for future database support.
  * Applications can extend this to initialize remote connections.
  */
-export function connect() {
+export async function connect() {
   if (client) return client;
   switch (DB_TYPE) {
-    case 'mongodb':
-    case 'mysql':
-    case 'postgres':
-    case 'firebase':
-      throw new Error('Remote database support not implemented yet');
+    case 'mongodb': {
+      client = new MongoClient(DB_URI);
+      await client.connect();
+      collection = client.db().collection('bydchain');
+      break;
+    }
+    case 'mysql': {
+      client = await mysql.createConnection({ uri: DB_URI, user: DB_USER, password: DB_PASSWORD });
+      await client.execute('CREATE TABLE IF NOT EXISTS storage (`key` VARCHAR(255) PRIMARY KEY, data JSON)');
+      break;
+    }
+    case 'postgres': {
+      client = new PgClient({ connectionString: DB_URI, user: DB_USER, password: DB_PASSWORD });
+      await client.connect();
+      await client.query('CREATE TABLE IF NOT EXISTS storage(key text primary key, data jsonb)');
+      break;
+    }
+    case 'firebase': {
+      const cert = FIREBASE_CERT && fs.existsSync(FIREBASE_CERT)
+        ? JSON.parse(fs.readFileSync(FIREBASE_CERT))
+        : null;
+      admin.initializeApp({
+        credential: admin.credential.cert(cert),
+        databaseURL: DB_URI,
+      });
+      client = admin.firestore();
+      break;
+    }
     default:
       client = null;
   }
@@ -45,23 +73,61 @@ export function connect() {
  * For remote databases this should be replaced with real queries.
  */
 export function save(key, data) {
-  if (DB_TYPE !== 'json') {
-    console.warn('Remote database support not implemented yet');
+  if (DB_TYPE === 'json') {
+    if (!fs.existsSync('storage')) fs.mkdirSync('storage', { recursive: true });
+    fs.writeFileSync(`storage/${key}.json`, JSON.stringify(data, null, 2));
     return;
   }
-  if (!fs.existsSync('storage')) fs.mkdirSync('storage', { recursive: true });
-  fs.writeFileSync(`storage/${key}.json`, JSON.stringify(data, null, 2));
+  return connect().then(async () => {
+    switch (DB_TYPE) {
+      case 'mongodb':
+      await collection.updateOne({ _id: key }, { $set: { data } }, { upsert: true });
+      break;
+      case 'mysql':
+      await client.execute('REPLACE INTO storage(`key`,`data`) VALUES (?, ?)', [key, JSON.stringify(data)]);
+      break;
+      case 'postgres':
+      await client.query('INSERT INTO storage(key,data) VALUES($1,$2) ON CONFLICT (key) DO UPDATE SET data=EXCLUDED.data', [key, data]);
+      break;
+      case 'firebase':
+      await client.collection('storage').doc(key).set({ data });
+      break;
+      default:
+      throw new Error(`Unsupported DB_TYPE ${DB_TYPE}`);
+    }
+  });
 }
 
 /**
  * Load JSON data previously stored with save().
  */
 export function load(key) {
-  if (DB_TYPE !== 'json') {
-    console.warn('Remote database support not implemented yet');
-    return null;
+  if (DB_TYPE === 'json') {
+    const file = `storage/${key}.json`;
+    if (!fs.existsSync(file)) return null;
+    return JSON.parse(fs.readFileSync(file));
   }
-  const file = `storage/${key}.json`;
-  if (!fs.existsSync(file)) return null;
-  return JSON.parse(fs.readFileSync(file));
+  return connect().then(async () => {
+    switch (DB_TYPE) {
+      case 'mongodb': {
+      const doc = await collection.findOne({ _id: key });
+      return doc ? doc.data : null;
+    }
+      case 'mysql': {
+      const [rows] = await client.execute('SELECT data FROM storage WHERE `key`=?', [key]);
+      if (rows.length === 0) return null;
+      return JSON.parse(rows[0].data);
+    }
+      case 'postgres': {
+      const res = await client.query('SELECT data FROM storage WHERE key=$1', [key]);
+      return res.rows[0] ? res.rows[0].data : null;
+    }
+      case 'firebase': {
+      const doc = await client.collection('storage').doc(key).get();
+      return doc.exists ? doc.data().data : null;
+    }
+      default:
+      throw new Error(`Unsupported DB_TYPE ${DB_TYPE}`);
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- implement MongoDB, MySQL, Postgres and Firebase adapters
- expose configuration via `DB_TYPE`, `DB_URI`, `DB_USER`, `DB_PASSWORD` and `FIREBASE_CERT`
- document environment variables in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866c90f24a083299f5fed41938680cb