### PR TITLE
Add Merkle proofs

### DIFF
--- a/__tests__/merkle.test.js
+++ b/__tests__/merkle.test.js
@@ -1,0 +1,28 @@
+import Blockchain from '../src/blockchain/index.js';
+import Wallet from '../src/wallet/index.js';
+import { getMerkleRoot, getMerkleProof } from '../src/blockchain/modules/merkle.js';
+
+describe('Merkle tree', () => {
+  test('block stores correct merkle root', () => {
+    const bc = new Blockchain();
+    const w = new Wallet(bc, 50);
+    w.stake(1);
+    const tx1 = w.createTransaction('a', 5);
+    const tx2 = w.createTransaction('b', 6);
+    const block = bc.addBlock([tx1, tx2], w);
+    const root = getMerkleRoot([tx1, tx2]);
+    expect(block.merkleRoot).toBe(root);
+  });
+
+  test('verifyMerkleProof validates inclusion', () => {
+    const bc = new Blockchain();
+    const w = new Wallet(bc, 50);
+    w.stake(1);
+    const tx1 = w.createTransaction('x', 1);
+    const tx2 = w.createTransaction('y', 2);
+    const block = bc.addBlock([tx1, tx2], w);
+    const proof = getMerkleProof([tx1, tx2], 1);
+    const valid = bc.verifyMerkleProof(tx2, proof, 1, block.merkleRoot);
+    expect(valid).toBe(true);
+  });
+});

--- a/src/blockchain/block.js
+++ b/src/blockchain/block.js
@@ -1,8 +1,9 @@
 import { gnHash } from '../modules/index.js';
 import adjustDifficulty from './modules/mdDifficulty.js';
+import { getMerkleRoot } from './modules/merkle.js';
 
 class Block {
-        constructor(timestamp, previousHash, data, hash, validator, signature, difficulty = 1) {
+        constructor(timestamp, previousHash, data, hash, validator, signature, difficulty = 1, merkleRoot = '') {
                 this.timestamp = timestamp;
                 this.previousHash = previousHash;
                 this.data = data;
@@ -10,6 +11,7 @@ class Block {
                 this.validator = validator;
                 this.signature = signature;
                 this.difficulty = difficulty;
+                this.merkleRoot = merkleRoot;
         }
 
         static get genesis() {
@@ -21,7 +23,8 @@ class Block {
                         'hash-genesis',
                         'genesis',
                         'genesis',
-                        1
+                        1,
+                        gnHash('S-U-N-I')
                 );
         }
 
@@ -34,13 +37,14 @@ class Block {
                                 ? validatorWallet
                                 : validatorWallet.publicKey;
                 const hash = Block.hash(timestamp, previousHash, data, validator, difficulty);
+                const merkleRoot = Array.isArray(data) ? getMerkleRoot(data) : gnHash(data);
                 let signature;
                 if (validatorWallet && typeof validatorWallet.sign === 'function') {
                         const sig = validatorWallet.sign(hash);
                         // store as hex string for serialization
                         signature = typeof sig.toDER === 'function' ? sig.toDER('hex') : sig;
                 }
-                return new this(timestamp, previousHash, data, hash, validator, signature, difficulty);
+                return new this(timestamp, previousHash, data, hash, validator, signature, difficulty, merkleRoot);
         }
 
         static hash(timestamp, previousHash, data, validator, difficulty){
@@ -56,7 +60,8 @@ class Block {
                         hash,
                         validator,
                         signature,
-                        difficulty
+                        difficulty,
+                        merkleRoot
                 } = this;
 
 		return ` BLOCK
@@ -67,6 +72,7 @@ class Block {
                 Validator: ${validator}
                 Signature: ${signature}
                 Difficulty: ${difficulty}
+                MerkleRoot: ${merkleRoot}
                 `;
         }
 

--- a/src/blockchain/blockchain.js
+++ b/src/blockchain/blockchain.js
@@ -2,6 +2,7 @@ import Block from './block.js';
 import validator from './modules/validator.js';
 import MemoryPool from './memPool.js';
 import { loadBlocks, saveBlocks, loadValidators, saveValidators } from './modules/storage.js';
+import { verifyProof } from './modules/merkle.js';
 
 const DELEGATE_COUNT = 5;
 
@@ -17,7 +18,9 @@ class Blockchain {
                                         b.data,
                                         b.hash,
                                         b.validator,
-                                        b.signature
+                                        b.signature,
+                                        b.difficulty,
+                                        b.merkleRoot
                                 )
                         );
                 } else {
@@ -244,6 +247,10 @@ class Blockchain {
                         if(Array.isArray(data)) txs.push(...data);
                 });
                 return txs;
+        }
+
+        verifyMerkleProof(tx, proof, index, merkleRoot){
+                return verifyProof(tx, proof, merkleRoot, index);
         }
 
         /**

--- a/src/blockchain/modules/merkle.js
+++ b/src/blockchain/modules/merkle.js
@@ -1,0 +1,63 @@
+import { gnHash } from '../../modules/index.js';
+
+function hashLeaf(data){
+    return gnHash(JSON.stringify(data));
+}
+
+export function getMerkleRoot(leaves){
+    if(!Array.isArray(leaves) || leaves.length === 0){
+        return gnHash('');
+    }
+    let level = leaves.map(hashLeaf);
+    while(level.length > 1){
+        if(level.length % 2 === 1){
+            level.push(level[level.length - 1]);
+        }
+        const next = [];
+        for(let i=0;i<level.length;i+=2){
+            next.push(gnHash(level[i] + level[i+1]));
+        }
+        level = next;
+    }
+    return level[0];
+}
+
+export function getMerkleProof(leaves, index){
+    if(!Array.isArray(leaves) || index < 0 || index >= leaves.length){
+        return [];
+    }
+    const hashes = leaves.map(hashLeaf);
+    let idx = index;
+    const proof = [];
+    let level = hashes;
+    while(level.length > 1){
+        if(level.length % 2 === 1){
+            level.push(level[level.length - 1]);
+        }
+        const pairIndex = idx % 2 === 0 ? idx + 1 : idx - 1;
+        proof.push(level[pairIndex]);
+        const next = [];
+        for(let i=0;i<level.length;i+=2){
+            next.push(gnHash(level[i] + level[i+1]));
+        }
+        idx = Math.floor(idx / 2);
+        level = next;
+    }
+    return proof;
+}
+
+export function verifyProof(leaf, proof, root, index){
+    let hash = hashLeaf(leaf);
+    let idx = index;
+    for(const sibling of proof){
+        if(idx % 2 === 0){
+            hash = gnHash(hash + sibling);
+        } else {
+            hash = gnHash(sibling + hash);
+        }
+        idx = Math.floor(idx / 2);
+    }
+    return hash === root;
+}
+
+export default { getMerkleRoot, getMerkleProof, verifyProof };

--- a/src/middleware/Api/Endpoints/index.js
+++ b/src/middleware/Api/Endpoints/index.js
@@ -23,6 +23,7 @@ import addressStats from './address_stats.js';
 import metrics from './metrics.js';
 import metricsExtended from './metrics_extended.js';
 import nodes from './nodes.js';
+import proof from './proof.js';
 
 const r = express.Router();
 
@@ -53,6 +54,9 @@ r.route('/block/:hash')
 
 r.route('/transaction/:id')
   .get(transactionGet);
+
+r.route('/proof/:txId')
+  .get(proof);
 
 r.route('/balance/:address')
 .get(balance);

--- a/src/middleware/Api/Endpoints/proof.js
+++ b/src/middleware/Api/Endpoints/proof.js
@@ -1,0 +1,22 @@
+import { blockchain } from '../../../service/context.js';
+import { getMerkleProof } from '../../../blockchain/modules/merkle.js';
+
+export default (req, res) => {
+  const { txId } = req.params;
+  for(let i = 0; i < blockchain.blocks.length; i++){
+    const { data } = blockchain.blocks[i];
+    if(Array.isArray(data)){
+      const index = data.findIndex(t => t.id === txId);
+      if(index >= 0){
+        const proof = getMerkleProof(data, index);
+        return res.json({
+          blockIndex: i,
+          index,
+          proof,
+          merkleRoot: blockchain.blocks[i].merkleRoot
+        });
+      }
+    }
+  }
+  res.status(404).json({ error: 'Transaction not found' });
+};


### PR DESCRIPTION
## Summary
- implement Merkle utilities
- store merkle root in each block
- add merkle proof verification in Blockchain
- expose `/api/proof/:txId` endpoint
- test merkle tree generation and proof verification

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866da3e41088329bb6394725d308c20