### PR TITLE
Add Prometheus metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The REST API exposes several helpers for querying the chain:
 - `GET /api/ai/list` – list all blocks that contain AI data
 - `GET /api/metrics` – retrieve overall blockchain statistics
 - `GET /api/metrics/extended` – retrieve advanced network statistics
+- `GET /api/metrics/prometheus` – metrics in Prometheus text format
+- `WS  /api/metrics/live` – live metrics over WebSocket
 
 ### Blockchain Utilities
 

--- a/src/middleware/Api/Endpoints/index.js
+++ b/src/middleware/Api/Endpoints/index.js
@@ -22,6 +22,7 @@ import addressTransactions from './address_transactions.js';
 import addressStats from './address_stats.js';
 import metrics from './metrics.js';
 import metricsExtended from './metrics_extended.js';
+import metricsPrometheus from './metrics_prometheus.js';
 import nodes from './nodes.js';
 import proof from './proof.js';
 
@@ -75,6 +76,9 @@ r.route('/metrics')
 
 r.route('/metrics/extended')
   .get(metricsExtended);
+
+r.route('/metrics/prometheus')
+  .get(metricsPrometheus);
 
 r.route('/nodes')
   .get(nodes);

--- a/src/middleware/Api/Endpoints/metrics_prometheus.js
+++ b/src/middleware/Api/Endpoints/metrics_prometheus.js
@@ -1,0 +1,33 @@
+import { blockchain, p2pAction } from '../../../service/context.js';
+
+export default (req, res) => {
+  const stats = blockchain.getExtendedStats();
+  const connectedNodes = p2pAction.sockets.length;
+
+  const lines = [
+    '# HELP bydchain_block_height Current chain length',
+    '# TYPE bydchain_block_height gauge',
+    `bydchain_block_height ${stats.chainLength}`,
+    '# HELP bydchain_total_transactions Total transactions on chain',
+    '# TYPE bydchain_total_transactions counter',
+    `bydchain_total_transactions ${stats.totalTransactions}`,
+    '# HELP bydchain_total_stake Sum of validator stakes',
+    '# TYPE bydchain_total_stake gauge',
+    `bydchain_total_stake ${stats.totalStake}`,
+    '# HELP bydchain_avg_block_time Average time between blocks',
+    '# TYPE bydchain_avg_block_time gauge',
+    `bydchain_avg_block_time ${stats.avgBlockTime}`,
+    '# HELP bydchain_mempool_size Pending transactions in mempool',
+    '# TYPE bydchain_mempool_size gauge',
+    `bydchain_mempool_size ${stats.mempoolSize}`,
+    '# HELP bydchain_connected_nodes Connected peers',
+    '# TYPE bydchain_connected_nodes gauge',
+    `bydchain_connected_nodes ${connectedNodes}`,
+    '# HELP bydchain_unique_addresses Unique addresses that have transacted',
+    '# TYPE bydchain_unique_addresses gauge',
+    `bydchain_unique_addresses ${stats.uniqueAddresses}`
+  ].join('\n');
+
+  res.set('Content-Type', 'text/plain');
+  res.send(lines + '\n');
+};


### PR DESCRIPTION
## Summary
- expose blockchain stats in Prometheus format
- document the new metrics endpoint and the websocket stream

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866fff4d0f4832992a6ed1fea48b7d1
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new /api/metrics/prometheus endpoint to expose blockchain stats in Prometheus format and updated the docs to include this and the live metrics WebSocket.

<!-- End of auto-generated description by cubic. -->

