### PR TITLE
Add extended metrics to analytics page

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ blocks are created in real time.
 - Export and import wallets using password‑encrypted keys
 - Search for an address to view its balance and transactions
 - Monitor real-time analytics from the **Analytics** page
+- View extended network statistics like total stake and unique addresses on the
+  **Analytics** page
 
 ## Professional Overview
 

--- a/pages/analytics.tsx
+++ b/pages/analytics.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
-const API_BASE = 'ws://localhost:8000';
+const API_BASE = 'http://localhost:8000';
+const WS_BASE = 'ws://localhost:8000';
 
 function LineChart({ data, color }) {
   if (data.length === 0) return <svg className="w-full h-32" />;
@@ -23,9 +24,10 @@ export default function Analytics() {
   const [blockTimes, setBlockTimes] = useState([]);
   const [mempoolSizes, setMempoolSizes] = useState([]);
   const [nodes, setNodes] = useState([]);
+  const [stats, setStats] = useState(null);
 
   useEffect(() => {
-    const ws = new WebSocket(`${API_BASE}/api/metrics/live`);
+    const ws = new WebSocket(`${WS_BASE}/api/metrics/live`);
     ws.onmessage = (ev) => {
       const data = JSON.parse(ev.data);
       setBlockTimes((b) => [...b.slice(-19), data.blockTime]);
@@ -35,9 +37,49 @@ export default function Analytics() {
     return () => ws.close();
   }, []);
 
+  useEffect(() => {
+    const load = () => {
+      fetch(`${API_BASE}/api/metrics/extended`)
+        .then((r) => r.json())
+        .then(setStats)
+        .catch(console.error);
+    };
+    load();
+    const id = setInterval(load, 5000);
+    return () => clearInterval(id);
+  }, []);
+
   return (
     <div className="py-6 space-y-6">
       <h1 className="text-2xl font-bold mb-4">Network Analytics</h1>
+      {stats && (
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          <div>
+            <h2 className="font-semibold">Block Height</h2>
+            <p>{stats.chainLength}</p>
+          </div>
+          <div>
+            <h2 className="font-semibold">Total Transactions</h2>
+            <p>{stats.totalTransactions}</p>
+          </div>
+          <div>
+            <h2 className="font-semibold">Average Block Time</h2>
+            <p>{stats.avgBlockTime.toFixed(2)} ms</p>
+          </div>
+          <div>
+            <h2 className="font-semibold">Total Stake</h2>
+            <p>{stats.totalStake}</p>
+          </div>
+          <div>
+            <h2 className="font-semibold">Mempool Size</h2>
+            <p>{stats.mempoolSize}</p>
+          </div>
+          <div>
+            <h2 className="font-semibold">Unique Addresses</h2>
+            <p>{stats.uniqueAddresses}</p>
+          </div>
+        </div>
+      )}
       <div>
         <h2 className="font-semibold">Block Time</h2>
         <LineChart data={blockTimes} color="skyblue" />


### PR DESCRIPTION
## Summary
- display extended blockchain metrics on `/analytics`
- poll metrics every 5 seconds in the frontend
- document viewing extended metrics in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6867032665bc8329ae25f4e846981008