### PR TITLE
Fix theme toggle

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -10,6 +10,11 @@ export default function Document(): ReactElement {
             __html: `(() => { try { const t = localStorage.getItem('theme') || 'dark'; document.documentElement.classList.add(t); } catch (_) {} })();`,
           }}
         />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `tailwind.config = { darkMode: 'class' }`,
+          }}
+        />
         <script src="https://cdn.tailwindcss.com"></script>
         <link
           href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&family=Raleway:wght@400;700&display=swap"


### PR DESCRIPTION
## Summary
- enable class-based dark mode configuration for Tailwind

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68670bd71a648329a170d235a358269f
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enabled class-based dark mode support for Tailwind to fix theme toggling. 

- **Bug Fixes**
  - Sets Tailwind dark mode to use the "class" strategy for correct theme switching.

<!-- End of auto-generated description by cubic. -->

