### PR TITLE
Add dropdown navigation under wallet

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -7,11 +7,13 @@ import { useTheme } from './ThemeContext'
 import ConnectWalletModal from './ConnectWalletModal'
 import SearchBar from './SearchBar'
 import { useWallet } from './WalletContext'
+import Link from 'next/link'
 
 export default function Layout({ children }: { children: ReactNode }) {
   const { theme, setTheme } = useTheme()
   const { wallet } = useWallet()
   const [modal, setModal] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
   const [height, setHeight] = useState<number | null>(null)
 
   useEffect(() => {
@@ -28,6 +30,18 @@ export default function Layout({ children }: { children: ReactNode }) {
     const id = setInterval(fetchHeight, 10000)
     return () => clearInterval(id)
   }, [])
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (!(e.target as HTMLElement).closest('#wallet-dropdown')) {
+        setMenuOpen(false)
+      }
+    }
+    if (menuOpen) {
+      document.addEventListener('click', handleClick)
+    }
+    return () => document.removeEventListener('click', handleClick)
+  }, [menuOpen])
   return (
     <div className="min-h-screen bg-background text-foreground">
       <header className="border-b bg-card shadow-sm">
@@ -65,9 +79,37 @@ export default function Layout({ children }: { children: ReactNode }) {
                 </span>
               </div>
               {wallet ? (
-                <Badge variant="outline" className="font-mono">
-                  {wallet.publicKey.slice(0, 6)}...{wallet.publicKey.slice(-4)}
-                </Badge>
+                <div className="relative" id="wallet-dropdown">
+                  <Badge
+                    variant="outline"
+                    className="font-mono cursor-pointer"
+                    onClick={() => setMenuOpen((o) => !o)}
+                  >
+                    {wallet.publicKey.slice(0, 6)}...{wallet.publicKey.slice(-4)}
+                  </Badge>
+                  {menuOpen && (
+                    <div className="absolute right-0 mt-2 w-48 bg-card border border-border rounded shadow z-50">
+                      <Link
+                        href="/send"
+                        className="block px-4 py-2 text-sm hover:bg-accent"
+                      >
+                        Send Transaction
+                      </Link>
+                      <Link
+                        href="/wallet"
+                        className="block px-4 py-2 text-sm hover:bg-accent"
+                      >
+                        Wallet
+                      </Link>
+                      <Link
+                        href="/analytics"
+                        className="block px-4 py-2 text-sm hover:bg-accent"
+                      >
+                        Analytics
+                      </Link>
+                    </div>
+                  )}
+                </div>
               ) : (
                 <Button
                   variant="outline"

--- a/pages/send.tsx
+++ b/pages/send.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+import { useWallet } from '../components/WalletContext'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+const API_BASE = 'http://localhost:8000'
+
+export default function Send() {
+  const { wallet, refreshBalance } = useWallet()
+  const [recipient, setRecipient] = useState('')
+  const [amount, setAmount] = useState('')
+  const [result, setResult] = useState<any>(null)
+
+  async function handleSend() {
+    if (!wallet) return
+    const res = await fetch(`${API_BASE}/api/transactions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ recipient, amount: parseFloat(amount) })
+    })
+    const json = await res.json()
+    setResult(json)
+    await refreshBalance()
+  }
+
+  return (
+    <div className="max-w-xl mx-auto py-6 space-y-4">
+      <h1 className="text-2xl font-bold">Send Transaction</h1>
+      {!wallet ? (
+        <p>Please connect a wallet.</p>
+      ) : (
+        <>
+          <Input
+            placeholder="Recipient address"
+            value={recipient}
+            onChange={(e) => setRecipient(e.target.value)}
+          />
+          <Input
+            placeholder="Amount"
+            type="number"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+          />
+          <Button onClick={handleSend}>Send</Button>
+          {result && (
+            <pre className="bg-gray-900 p-3 rounded overflow-auto">
+              {JSON.stringify(result, null, 2)}
+            </pre>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/pages/wallet.tsx
+++ b/pages/wallet.tsx
@@ -1,0 +1,1 @@
+export { default } from './profile'


### PR DESCRIPTION
## Summary
- add dropdown menu under wallet badge
- close dropdown on outside click
- provide new pages for sending transactions and viewing the wallet

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68670d9f06608329a923d23ffad88934