### PR TITLE
Add wallet management and export options

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useEffect, useState } from 'react'
 import { Blocks, Sun, Moon, Network } from 'lucide-react'
+import { FaSignOutAlt } from 'react-icons/fa'
 import { Button } from './ui/button'
 import { Badge } from './ui/badge'
 import { Switch } from './ui/switch'
@@ -11,7 +12,7 @@ import Link from 'next/link'
 
 export default function Layout({ children }: { children: ReactNode }) {
   const { theme, setTheme } = useTheme()
-  const { wallet } = useWallet()
+  const { wallet, logout } = useWallet()
   const [modal, setModal] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const [height, setHeight] = useState<number | null>(null)
@@ -88,26 +89,38 @@ export default function Layout({ children }: { children: ReactNode }) {
                     {wallet.publicKey.slice(0, 6)}...{wallet.publicKey.slice(-4)}
                   </Badge>
                   {menuOpen && (
-                    <div className="absolute right-0 mt-2 w-48 bg-card border border-border rounded shadow z-50">
-                      <Link
-                        href="/send"
-                        className="block px-4 py-2 text-sm hover:bg-accent"
-                      >
-                        Send Transaction
-                      </Link>
-                      <Link
-                        href="/wallet"
-                        className="block px-4 py-2 text-sm hover:bg-accent"
-                      >
-                        Wallet
-                      </Link>
-                      <Link
-                        href="/analytics"
-                        className="block px-4 py-2 text-sm hover:bg-accent"
-                      >
-                        Analytics
-                      </Link>
-                    </div>
+                    <>
+                      <div className="fixed inset-0 bg-black/50 z-40" />
+                      <div className="absolute right-0 mt-2 w-48 bg-card border border-border rounded shadow z-50">
+                        <Link
+                          href="/send"
+                          className="block px-4 py-2 text-sm hover:bg-accent"
+                        >
+                          Send Transaction
+                        </Link>
+                        <Link
+                          href="/wallet"
+                          className="block px-4 py-2 text-sm hover:bg-accent"
+                        >
+                          Wallet
+                        </Link>
+                        <Link
+                          href="/analytics"
+                          className="block px-4 py-2 text-sm hover:bg-accent"
+                        >
+                          Analytics
+                        </Link>
+                        <button
+                          onClick={() => {
+                            logout()
+                            setMenuOpen(false)
+                          }}
+                          className="w-full text-left px-4 py-2 text-sm hover:bg-accent flex items-center gap-2"
+                        >
+                          <FaSignOutAlt className="inline" /> Logout
+                        </button>
+                      </div>
+                    </>
                   )}
                 </div>
               ) : (

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useState } from 'react'
+import { FaPlus, FaSignOutAlt, FaKey } from 'react-icons/fa'
 import { useWallet } from '../components/WalletContext'
+import { Button } from '@/components/ui/button'
 
 export default function Profile() {
-  const { wallet, exportMnemonic, refreshBalance } = useWallet()
+  const { wallet, wallets, createWallet, selectWallet, logout, exportMnemonic, exportKeys, refreshBalance } = useWallet()
   const [mnemonic, setMnemonic] = useState<string | null>(null)
+  const [keys, setKeys] = useState<{ privateKey: string; publicKey: string } | null>(null)
 
   useEffect(() => {
     if (wallet) refreshBalance()
@@ -12,15 +15,44 @@ export default function Profile() {
   async function handleExport() {
     const m = await exportMnemonic()
     setMnemonic(m)
+    const k = await exportKeys()
+    setKeys(k)
   }
 
   if (!wallet) {
-    return <div className="py-6">No wallet connected.</div>
+    return (
+      <div className="py-6 space-y-4">
+        <p>No wallet connected.</p>
+        <Button onClick={createWallet} disabled={wallets.length >= 10} className="gap-2">
+          <FaPlus /> Create Wallet
+        </Button>
+      </div>
+    )
   }
 
   return (
     <div className="max-w-xl mx-auto py-6 space-y-4">
       <h1 className="text-2xl font-bold">Profile</h1>
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <h2 className="font-semibold">Wallets</h2>
+          <Button onClick={createWallet} disabled={wallets.length >= 10} size="sm" className="gap-2">
+            <FaPlus /> New
+          </Button>
+        </div>
+        <ul className="space-y-1">
+          {wallets.map((w) => (
+            <li key={w.publicKey} className="flex items-center justify-between text-sm">
+              <button className="font-mono hover:underline" onClick={() => selectWallet(w.publicKey)}>
+                {w.publicKey.slice(0, 10)}...
+              </button>
+              {wallet && wallet.publicKey === w.publicKey && (
+                <span className="text-xs text-green-500">active</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
       <div className="bg-black border border-gray-700 p-4 rounded space-y-2">
         <div>
           <span className="font-semibold">Public Key:</span>
@@ -32,15 +64,20 @@ export default function Profile() {
         </div>
       </div>
       <div className="space-x-2">
-        <button
-          onClick={handleExport}
-          className="px-4 py-2 bg-indigo-500 text-white rounded"
-        >
-          Export Keys
-        </button>
+        <Button onClick={handleExport} className="gap-2">
+          <FaKey className="inline" /> Export Keys
+        </Button>
+        <Button onClick={logout} variant="outline" className="gap-2">
+          <FaSignOutAlt /> Logout
+        </Button>
       </div>
       {mnemonic && (
         <pre className="bg-gray-900 p-3 rounded break-all">{mnemonic}</pre>
+      )}
+      {keys && (
+        <pre className="bg-gray-900 p-3 rounded break-all whitespace-pre-wrap">
+{`Public: ${keys.publicKey}\nPrivate: ${keys.privateKey}`}
+        </pre>
       )}
     </div>
   )

--- a/src/middleware/Api/Endpoints/index.js
+++ b/src/middleware/Api/Endpoints/index.js
@@ -8,6 +8,7 @@ import walletStake from './wallet_stake.js';
 import walletList from './wallet_list.js';
 import walletExport from './wallet_export.js';
 import walletImport from './wallet_import.js';
+import walletKeys from './wallet_keys.js';
 import mine from './mine.js';
 import transactionsNew from './transactions_new.js';
 import aiStore from './ai_store.js';
@@ -109,6 +110,9 @@ r.route('/wallet/export')
 
 r.route('/wallet/import')
   .post(walletImport);
+
+r.route('/wallet/keys')
+  .post(walletKeys);
 
 
 r.route('/mine')

--- a/src/middleware/Api/Endpoints/wallet_keys.js
+++ b/src/middleware/Api/Endpoints/wallet_keys.js
@@ -1,0 +1,23 @@
+import { wallets } from '../../../service/context.js';
+import Joi from '../../../utils/validator.js';
+
+const schema = Joi.object({
+  address: Joi.string().hex().required()
+});
+
+export default (req, res) => {
+  const { error, value } = schema.validate(req.body || {});
+  if (error) {
+    return res.status(400).json({ status: 0, error });
+  }
+  const { address } = value;
+  const wallet = wallets.find((w) => w.publicKey === address);
+  if (!wallet) {
+    return res.json({ status: 0, error: 'Wallet not found' });
+  }
+  res.json({
+    status: 'ok',
+    publicKey: wallet.publicKey,
+    privateKey: wallet.exportPrivateKey ? wallet.exportPrivateKey() : wallet.keyPair.getPrivate('hex')
+  });
+};

--- a/src/wallet/wallet.js
+++ b/src/wallet/wallet.js
@@ -64,6 +64,10 @@ class Wallet{
                 return Wallet.encryptPrivateKey(this.keyPair.getPrivate('hex'), password);
         }
 
+        exportPrivateKey(){
+                return this.keyPair.getPrivate('hex');
+        }
+
         static fromMnemonic(blockchain, mnemonic, initBalance = INIT_BL, path = "m/44'/0'/0'/0/0"){ 
                 return new Wallet(blockchain, initBalance, mnemonic, path);
         }


### PR DESCRIPTION
## Summary
- support exporting private keys on server
- provide `/wallet/keys` endpoint
- manage up to ten wallets in `WalletContext`
- allow logout and wallet switching from new submenu
- display wallets and export keys on profile page

## Testing
- `npm test` *(fails: jest not found)*
- `npm run eslint` *(fails: missing ESLint config)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68670fe8e24c8329ab3a57cf943a382e
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added wallet management features, including support for up to ten wallets, wallet switching, logout, and private key export from the profile page.

- **New Features**
  - Export private keys via a new `/wallet/keys` API endpoint.
  - Manage and switch between multiple wallets in the UI.
  - Logout and wallet switching options in the menu and profile page.

<!-- End of auto-generated description by cubic. -->

