### PR TITLE
Add wallet enhancements

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -45,7 +45,7 @@ export default function Layout({ children }: { children: ReactNode }) {
   }, [menuOpen])
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <header className="border-b bg-card shadow-sm">
+      <header className="border-b bg-card shadow-sm" style={{ fontFamily: 'Nunito, sans-serif' }}>
         <div className="container mx-auto px-4 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4">

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -17,13 +17,13 @@ export default function Document(): ReactElement {
         />
         <script src="https://cdn.tailwindcss.com"></script>
         <link
-          href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&family=Raleway:wght@400;700&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&family=IBM+Plex+Sans:wght@400;700&display=swap"
           rel="stylesheet"
         />
       </Head>
       <body
         className="bg-white text-black dark:bg-black dark:text-white transition-colors duration-300"
-        style={{ fontFamily: 'Nunito, Raleway, sans-serif' }}
+        style={{ fontFamily: "'__IBM_Plex_Sans_ce9353','__IBM_Plex_Sans_Fallback_ce9353', sans-serif" }}
       >
         <Main />
         <NextScript />

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useState } from 'react'
-import { FaPlus, FaSignOutAlt, FaKey } from 'react-icons/fa'
+import { FaPlus, FaSignOutAlt, FaKey, FaStar, FaDownload } from 'react-icons/fa'
 import { useWallet } from '../components/WalletContext'
 import { Button } from '@/components/ui/button'
 
 export default function Profile() {
-  const { wallet, wallets, createWallet, selectWallet, logout, exportMnemonic, exportKeys, refreshBalance } = useWallet()
+  const { wallet, wallets, createWallet, selectWallet, toggleFavorite, exportJson, logout, exportMnemonic, exportKeys, refreshBalance } = useWallet()
   const [mnemonic, setMnemonic] = useState<string | null>(null)
   const [keys, setKeys] = useState<{ privateKey: string; publicKey: string } | null>(null)
+  const [page, setPage] = useState(0)
+  const perPage = 5
 
   useEffect(() => {
     if (wallet) refreshBalance()
@@ -19,11 +21,23 @@ export default function Profile() {
     setKeys(k)
   }
 
+  function handleExportJson(address: string) {
+    const data = exportJson(address)
+    if (!data) return
+    const blob = new Blob([data], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${address}.json`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
   if (!wallet) {
     return (
       <div className="py-6 space-y-4">
         <p>No wallet connected.</p>
-        <Button onClick={createWallet} disabled={wallets.length >= 10} className="gap-2">
+        <Button onClick={createWallet} className="gap-2">
           <FaPlus /> Create Wallet
         </Button>
       </div>
@@ -36,22 +50,43 @@ export default function Profile() {
       <div className="space-y-2">
         <div className="flex items-center justify-between">
           <h2 className="font-semibold">Wallets</h2>
-          <Button onClick={createWallet} disabled={wallets.length >= 10} size="sm" className="gap-2">
+          <Button onClick={createWallet} size="sm" className="gap-2">
             <FaPlus /> New
           </Button>
         </div>
         <ul className="space-y-1">
-          {wallets.map((w) => (
-            <li key={w.publicKey} className="flex items-center justify-between text-sm">
-              <button className="font-mono hover:underline" onClick={() => selectWallet(w.publicKey)}>
+          {wallets.slice(page * perPage, (page + 1) * perPage).map((w) => (
+            <li key={w.publicKey} className="flex items-center justify-between text-sm gap-2">
+              <button
+                className="font-mono hover:underline"
+                onClick={() => selectWallet(w.publicKey)}
+              >
                 {w.publicKey.slice(0, 10)}...
               </button>
-              {wallet && wallet.publicKey === w.publicKey && (
-                <span className="text-xs text-green-500">active</span>
-              )}
+              <div className="flex items-center gap-2">
+                <FaStar
+                  className={w.favorite ? 'text-yellow-400 cursor-pointer' : 'text-gray-500 cursor-pointer'}
+                  onClick={() => toggleFavorite(w.publicKey)}
+                />
+                <FaDownload className="cursor-pointer" onClick={() => handleExportJson(w.publicKey)} />
+                {wallet && wallet.publicKey === w.publicKey && (
+                  <span className="text-xs text-green-500">active</span>
+                )}
+              </div>
             </li>
           ))}
         </ul>
+        {wallets.length > perPage && (
+          <div className="flex justify-between mt-2 text-sm">
+            <Button variant="outline" size="sm" disabled={page === 0} onClick={() => setPage((p) => Math.max(0, p - 1))}>
+              Prev
+            </Button>
+            <span className="mx-2 flex-1 text-center">Page {page + 1} / {Math.ceil(wallets.length / perPage)}</span>
+            <Button variant="outline" size="sm" disabled={(page + 1) * perPage >= wallets.length} onClick={() => setPage((p) => p + 1)}>
+              Next
+            </Button>
+          </div>
+        )}
       </div>
       <div className="bg-black border border-gray-700 p-4 rounded space-y-2">
         <div>

--- a/src/middleware/Api/Endpoints/wallet_new.js
+++ b/src/middleware/Api/Endpoints/wallet_new.js
@@ -1,5 +1,6 @@
-import Wallet from '../../../wallet/index.js';
-import context, { blockchain, wallets } from '../../../service/context.js';
+import Wallet, { Transaction, blockchainWallet } from '../../../wallet/index.js';
+import { INIT_BL } from '../../../wallet/wallet.js';
+import context, { blockchain, wallets, walletMiner } from '../../../service/context.js';
 import Joi from '../../../utils/validator.js';
 
 const schema = Joi.object({
@@ -13,15 +14,25 @@ export default (req, res) => {
         }
         const { password } = value;
 
-        const wallet = new Wallet(blockchain, 20);
+        const wallet = new Wallet(blockchain, 0);
         if(password){
                 wallet.saveEncrypted(password);
         }
+
+        // credit the new wallet on chain so balance persists
+        const tx = Transaction.create(blockchainWallet, wallet.publicKey, INIT_BL);
+        blockchain.addBlock([tx], walletMiner);
+
         context.currentWallet = wallet;
         wallets.push(wallet);
 
+        const data = {
+                publicKey: wallet.publicKey,
+                balance: blockchain.getBalance(wallet.publicKey)
+        };
+
         res.json({
                 status: 'ok',
-                data: wallet.blockchainWallet()
+                data
         });
 };


### PR DESCRIPTION
## Summary
- fix wallet balance persistence by funding new wallets on chain
- allow unlimited wallets, toggle favorites, and export wallets as JSON
- paginate wallet list and improve wallet actions
- apply Nunito font to header and IBM Plex Sans to body

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868bb89297c8329a57d2920dda6c58b
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved wallet features by funding new wallets on-chain, allowing unlimited wallets, adding favorites, export as JSON, and paginating the wallet list. Updated header and body fonts for better readability.

- **New Features**
  - New wallets are funded on creation so balances persist.
  - Unlimited wallets supported.
  - Mark wallets as favorites and export wallets as JSON.
  - Paginated wallet list and improved wallet actions.
  - Header uses Nunito font; body uses IBM Plex Sans.

<!-- End of auto-generated description by cubic. -->

