### PR TITLE
Improve profile wallet page

### DIFF
--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { FaPlus, FaSignOutAlt, FaKey, FaStar, FaDownload } from 'react-icons/fa'
 import { useWallet } from '../components/WalletContext'
 import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 
 export default function Profile() {
   const { wallet, wallets, createWallet, selectWallet, toggleFavorite, exportJson, logout, exportMnemonic, exportKeys, refreshBalance } = useWallet()
@@ -45,75 +46,94 @@ export default function Profile() {
   }
 
   return (
-    <div className="max-w-xl mx-auto py-6 space-y-4">
-      <h1 className="text-2xl font-bold">Profile</h1>
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <h2 className="font-semibold">Wallets</h2>
-          <Button onClick={createWallet} size="sm" className="gap-2">
-            <FaPlus /> New
-          </Button>
-        </div>
-        <ul className="space-y-1">
-          {wallets.slice(page * perPage, (page + 1) * perPage).map((w) => (
-            <li key={w.publicKey} className="flex items-center justify-between text-sm gap-2">
-              <button
-                className="font-mono hover:underline"
-                onClick={() => selectWallet(w.publicKey)}
-              >
-                {w.publicKey.slice(0, 10)}...
-              </button>
-              <div className="flex items-center gap-2">
-                <FaStar
-                  className={w.favorite ? 'text-yellow-400 cursor-pointer' : 'text-gray-500 cursor-pointer'}
-                  onClick={() => toggleFavorite(w.publicKey)}
-                />
-                <FaDownload className="cursor-pointer" onClick={() => handleExportJson(w.publicKey)} />
-                {wallet && wallet.publicKey === w.publicKey && (
-                  <span className="text-xs text-green-500">active</span>
-                )}
+    <div className="bg-neutral-950">
+      <div className="max-w-4xl mx-auto py-8 space-y-8 text-white font-medium">
+        <h1 className="text-2xl font-semibold">Profile</h1>
+        <div className="grid gap-8 md:grid-cols-2">
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h2 className="text-neutral-400">Wallets</h2>
+              <Button onClick={createWallet} size="sm" className="gap-2">
+                <FaPlus /> New Wallet
+              </Button>
+            </div>
+            <ul className="space-y-1">
+              {wallets.slice(page * perPage, (page + 1) * perPage).map((w) => (
+                <li
+                  key={w.publicKey}
+                  className="flex items-center justify-between text-sm hover:bg-white/5 px-4 py-2 rounded-md"
+                >
+                  <button className="font-mono" onClick={() => selectWallet(w.publicKey)}>
+                    {w.publicKey.slice(0, 10)}...
+                  </button>
+                  <div className="flex items-center gap-3">
+                    <FaStar
+                      className={cn(
+                        'cursor-pointer hover:text-yellow-400',
+                        w.favorite ? 'text-yellow-400' : 'text-neutral-400'
+                      )}
+                      onClick={() => toggleFavorite(w.publicKey)}
+                    />
+                    <FaDownload
+                      className="cursor-pointer text-neutral-400 hover:text-blue-400"
+                      onClick={() => handleExportJson(w.publicKey)}
+                    />
+                  </div>
+                </li>
+              ))}
+            </ul>
+            {wallets.length > perPage && (
+              <div className="flex justify-between pt-2 text-sm">
+                <button
+                  className="px-3 py-1 rounded-full hover:bg-white/10 transition disabled:opacity-50"
+                  disabled={page === 0}
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                >
+                  Prev
+                </button>
+                <span className="mx-2 flex-1 text-center text-neutral-400">
+                  Page {page + 1} / {Math.ceil(wallets.length / perPage)}
+                </span>
+                <button
+                  className="px-3 py-1 rounded-full hover:bg-white/10 transition disabled:opacity-50"
+                  disabled={(page + 1) * perPage >= wallets.length}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  Next
+                </button>
               </div>
-            </li>
-          ))}
-        </ul>
-        {wallets.length > perPage && (
-          <div className="flex justify-between mt-2 text-sm">
-            <Button variant="outline" size="sm" disabled={page === 0} onClick={() => setPage((p) => Math.max(0, p - 1))}>
-              Prev
-            </Button>
-            <span className="mx-2 flex-1 text-center">Page {page + 1} / {Math.ceil(wallets.length / perPage)}</span>
-            <Button variant="outline" size="sm" disabled={(page + 1) * perPage >= wallets.length} onClick={() => setPage((p) => p + 1)}>
-              Next
-            </Button>
+            )}
           </div>
-        )}
-      </div>
-      <div className="bg-black border border-gray-700 p-4 rounded space-y-2">
-        <div>
-          <span className="font-semibold">Public Key:</span>
-          <span className="ml-2 break-all">{wallet.publicKey}</span>
+          <div className="space-y-4 flex flex-col">
+            <div className="bg-white/5 rounded-xl p-4 border border-white/10 space-y-2">
+              <div>
+                <span className="text-neutral-400">Public Key:</span>
+                <p className="font-mono break-all text-xs mt-1">{wallet.publicKey}</p>
+              </div>
+              <div>
+                <span className="text-neutral-400">Balance:</span>
+                <span className={cn('ml-2', wallet.balance > 0 ? 'text-green-400' : 'text-white')}>
+                  {wallet.balance}
+                </span>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button onClick={handleExport} className="gap-2 bg-white text-black hover:bg-white/80">
+                <FaKey /> Export Keys
+              </Button>
+              <Button onClick={logout} variant="ghost" className="gap-2 hover:text-red-400">
+                <FaSignOutAlt /> Logout
+              </Button>
+            </div>
+            {mnemonic && (
+              <pre className="bg-black/40 p-3 rounded break-all font-mono text-xs">{mnemonic}</pre>
+            )}
+            {keys && (
+              <pre className="bg-black/40 p-3 rounded break-all whitespace-pre-wrap font-mono text-xs">{`Public: ${keys.publicKey}\nPrivate: ${keys.privateKey}`}</pre>
+            )}
+          </div>
         </div>
-        <div>
-          <span className="font-semibold">Balance:</span>
-          <span className="ml-2">{wallet.balance}</span>
-        </div>
       </div>
-      <div className="space-x-2">
-        <Button onClick={handleExport} className="gap-2">
-          <FaKey className="inline" /> Export Keys
-        </Button>
-        <Button onClick={logout} variant="outline" className="gap-2">
-          <FaSignOutAlt /> Logout
-        </Button>
-      </div>
-      {mnemonic && (
-        <pre className="bg-gray-900 p-3 rounded break-all">{mnemonic}</pre>
-      )}
-      {keys && (
-        <pre className="bg-gray-900 p-3 rounded break-all whitespace-pre-wrap">
-{`Public: ${keys.publicKey}\nPrivate: ${keys.privateKey}`}
-        </pre>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- redesign profile page with dark wallet layout

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868c2d2ee388329813cca13e7e5a705
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Redesigned the profile wallet page with a new dark layout and improved wallet list, making it easier to view and manage wallets.

- **UI Improvements**
  - Added a dark background and updated styling for better readability.
  - Improved wallet list with clearer actions and navigation.
  - Enhanced wallet details section with updated balance and export options.

<!-- End of auto-generated description by cubic. -->

