### PR TITLE
Fix validator persistence for wallet creation

### DIFF
--- a/src/service/context.js
+++ b/src/service/context.js
@@ -2,10 +2,37 @@ import Blockchain from '../blockchain/index.js';
 import P2PAction from './p2p.js';
 import Wallet from '../wallet/index.js';
 import Miner from '../miner/index.js';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
 const blockchain = new Blockchain();
 const wallets = [];
-const walletMiner = new Wallet(blockchain, 0);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MINER_KEY_FILE = path.join(__dirname, '../storage/miner.key');
+
+let walletMiner;
+if (existsSync(MINER_KEY_FILE)) {
+  try {
+    const priv = readFileSync(MINER_KEY_FILE, 'utf8');
+    walletMiner = Wallet.fromPrivateKey(blockchain, priv.trim(), 0);
+  } catch {
+    walletMiner = new Wallet(blockchain, 0);
+  }
+} else {
+  walletMiner = new Wallet(blockchain, 0);
+  try {
+    writeFileSync(MINER_KEY_FILE, walletMiner.exportPrivateKey());
+  } catch {
+    /* ignore persistence errors */
+  }
+}
+
+if (blockchain.getStakeOf(walletMiner.publicKey) === 0) {
+  blockchain.registerStake(walletMiner.publicKey, 1);
+}
+
 const p2pAction = new P2PAction(blockchain);
 const miner = new Miner(blockchain, p2pAction, walletMiner);
 


### PR DESCRIPTION
## Summary
- persist miner wallet private key between restarts
- auto register the miner wallet as a validator when loading the service context

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868c6f56eec8329a2d2796467900450
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Miner wallet private keys are now saved to disk and reloaded on restart. The miner wallet is also auto-registered as a validator if it has no stake.

<!-- End of auto-generated description by cubic. -->

