### PR TITLE
Fix delegate selection for wallet creation

### DIFF
--- a/src/blockchain/blockchain.js
+++ b/src/blockchain/blockchain.js
@@ -148,6 +148,21 @@ class Blockchain {
                 }
         }
 
+        /**
+         * Ensure the given address is the current delegate
+         * @param {string} address
+         * @returns {boolean} true if delegate changed
+         */
+        setCurrentDelegate(address){
+                this.delegates = this.computeDelegates();
+                const idx = this.delegates.indexOf(address);
+                if(idx !== -1){
+                        this.delegateIndex = idx;
+                        return true;
+                }
+                return false;
+        }
+
         selectValidator(){
                 const entries = Object.entries(this.validators);
                 const total = entries.reduce((t, [, stake]) => t + Number(stake), 0);

--- a/src/middleware/Api/Endpoints/ai_store.js
+++ b/src/middleware/Api/Endpoints/ai_store.js
@@ -15,6 +15,7 @@ export default (req, res) => {
     }
     const { model, description, dataHash } = value;
     try {
+        blockchain.setCurrentDelegate(walletMiner.publicKey);
         const block = blockchain.addBlock(
             { type: 'AI_DATA', model, description, hash: dataHash },
             walletMiner

--- a/src/middleware/Api/Endpoints/mine.js
+++ b/src/middleware/Api/Endpoints/mine.js
@@ -12,6 +12,7 @@ export default (req, res) => {
                 return res.status(400).json({ status: 0, error });
         }
 
+        blockchain.setCurrentDelegate(walletMiner.publicKey);
         const block = blockchain.addBlock(value.data, walletMiner);
         p2pAction.sync();
 

--- a/src/middleware/Api/Endpoints/wallet_new.js
+++ b/src/middleware/Api/Endpoints/wallet_new.js
@@ -21,6 +21,7 @@ export default (req, res) => {
 
         // credit the new wallet on chain so balance persists
         const tx = Transaction.create(blockchainWallet, wallet.publicKey, INIT_BL);
+        blockchain.setCurrentDelegate(walletMiner.publicKey);
         blockchain.addBlock([tx], walletMiner);
 
         context.currentWallet = wallet;


### PR DESCRIPTION
## Summary
- ensure walletMiner is used as delegate when mining special blocks
- expose `setCurrentDelegate` helper on the blockchain

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868c7ede720832982811739f3a5048c
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed delegate selection when creating wallets and mining special blocks to ensure the correct delegate is used.

- **Bug Fixes**
  - Added setCurrentDelegate to set the delegate before mining or wallet creation.
  - Updated endpoints to call setCurrentDelegate with walletMiner.

<!-- End of auto-generated description by cubic. -->

