### PR TITLE
Fix transaction sending

### DIFF
--- a/pages/SendTransactionPage.tsx
+++ b/pages/SendTransactionPage.tsx
@@ -66,12 +66,21 @@ export default function SendTransactionPage() {
     setModal(false)
     setLoading(true)
     try {
-      // mock sending
-      await new Promise(res => setTimeout(res, 1500))
-      const hash = randomHash()
-      setTxHash(hash)
-      setToast('Transaction sent!')
-      await refreshBalance()
+      const res = await fetch(`${API_BASE}/api/transactions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ recipient: to, amount: parseFloat(amount) })
+      })
+      const data = await res.json()
+      if (res.ok) {
+        setTxHash(data.id || null)
+        setToast('Transaction sent!')
+        await refreshBalance()
+      } else {
+        setToast(data.error || 'Transaction failed')
+      }
+    } catch {
+      setToast('Transaction failed')
     } finally {
       setLoading(false)
     }


### PR DESCRIPTION
## Summary
- implement real transaction sending API call in SendTransactionPage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868cbe8df84832988a4b6ce6cf217b6
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced the mock transaction logic with a real API call to send transactions from the SendTransactionPage. Now shows success or error messages based on the API response.

<!-- End of auto-generated description by cubic. -->

