### PR TITLE
Add wallet status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The REST API exposes several helpers for querying the chain:
 - `GET /api/verify` – check whether the chain is valid
 - `GET /api/block/:hash` – fetch a block by its hash
 - `GET /api/balance/:address` – show the balance of a wallet address
+- `GET /api/wallet/status` – check if a wallet is currently active
 - `GET /api/address/:address/transactions` – list all transactions involving an address
 - `GET /api/address/:address/stats` – summarize sent and received amounts for an address
 - `GET /api/ai/list` – list all blocks that contain AI data

--- a/src/middleware/Api/Endpoints/index.js
+++ b/src/middleware/Api/Endpoints/index.js
@@ -6,6 +6,7 @@ import walletNew from './wallet_new.js';
 import walletAccess from './wallet_access.js';
 import walletStake from './wallet_stake.js';
 import walletList from './wallet_list.js';
+import walletStatus from './wallet_status.js';
 import walletExport from './wallet_export.js';
 import walletImport from './wallet_import.js';
 import walletKeys from './wallet_keys.js';
@@ -90,6 +91,9 @@ r.route('/search')
 
 r.route('/wallet/list')
   .get(walletList);
+
+r.route('/wallet/status')
+  .get(walletStatus);
 
 
 /**

--- a/src/middleware/Api/Endpoints/wallet_status.js
+++ b/src/middleware/Api/Endpoints/wallet_status.js
@@ -1,0 +1,12 @@
+import { currentWallet } from '../../../service/context.js';
+
+export default (req, res) => {
+  if (!currentWallet) {
+    return res.json({ status: 'ok', active: false });
+  }
+  res.json({
+    status: 'ok',
+    active: true,
+    data: currentWallet.blockchainWallet()
+  });
+};


### PR DESCRIPTION
## Summary
- add API route `/wallet/status` to check active wallet
- document the new endpoint in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868cf9923e483298a74fe51a516ab51
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new GET /api/wallet/status endpoint to check if a wallet is active, and updated the README with usage details.

<!-- End of auto-generated description by cubic. -->

