### PR TITLE
Fix send transactions with 0x addresses

### DIFF
--- a/src/middleware/Api/Endpoints/transactions_new.js
+++ b/src/middleware/Api/Endpoints/transactions_new.js
@@ -3,7 +3,7 @@ import { currentWallet, p2pAction } from '../../../service/context.js';
 import Joi from '../../../utils/validator.js';
 
 const schema = Joi.object({
-    recipient: Joi.string().hex().required(),
+    recipient: Joi.string().required(),
     amount: Joi.number().positive().required(),
     script: Joi.string().allow('', null)
 });
@@ -13,14 +13,21 @@ export default (req, res) => {
         if (error) {
                 return res.status(400).json({ status: 0, error });
         }
-        const { recipient, amount, script } = value;
+        let { recipient, amount, script } = value;
+        recipient = recipient.trim();
+        if(recipient.startsWith('0x') || recipient.startsWith('0X')){
+                recipient = recipient.slice(2);
+        }
+        if(!/^[a-fA-F0-9]+$/.test(recipient)){
+                return res.status(400).json({ error: 'Invalid recipient address' });
+        }
 
         if(!currentWallet){
                 return res.status(400).json({ error: 'No hay una wallet activa' });
         }
 
         try{
-                const tr = currentWallet.createTransaction(recipient.trim(), amount, script);
+                const tr = currentWallet.createTransaction(recipient, amount, script);
                 p2pAction.broadcast(MESSAGE.TR, tr);
                 res.json(tr);
         }catch(error){


### PR DESCRIPTION
## Summary
- relax recipient validation in transactions endpoint
- strip `0x` prefix so the API accepts hex addresses starting with `0x`

## Testing
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6868d207826483298ebba50ff72e130c