### PR TITLE
Fix transaction creation when wallet not active

### DIFF
--- a/pages/SendTransactionPage.tsx
+++ b/pages/SendTransactionPage.tsx
@@ -69,7 +69,7 @@ export default function SendTransactionPage() {
       const res = await fetch(`${API_BASE}/api/transactions`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ recipient: to, amount: parseFloat(amount) })
+        body: JSON.stringify({ recipient: to, amount: parseFloat(amount), sender: from })
       })
       const data = await res.json()
       if (res.ok) {

--- a/pages/send.tsx
+++ b/pages/send.tsx
@@ -17,7 +17,7 @@ export default function Send() {
     const res = await fetch(`${API_BASE}/api/transactions`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ recipient, amount: parseFloat(amount) })
+      body: JSON.stringify({ recipient, amount: parseFloat(amount), sender: wallet.publicKey })
     })
     const json = await res.json()
     await refreshBalance()

--- a/src/middleware/Api/Endpoints/transactions_new.js
+++ b/src/middleware/Api/Endpoints/transactions_new.js
@@ -1,11 +1,12 @@
 import { MESSAGE } from '../../../service/p2p.js';
-import { currentWallet, p2pAction } from '../../../service/context.js';
+import { currentWallet, wallets, p2pAction } from '../../../service/context.js';
 import Joi from '../../../utils/validator.js';
 
 const schema = Joi.object({
     recipient: Joi.string().required(),
     amount: Joi.number().positive().required(),
-    script: Joi.string().allow('', null)
+    script: Joi.string().allow('', null),
+    sender: Joi.string().allow('', null)
 });
 
 export default (req, res) => {
@@ -13,7 +14,7 @@ export default (req, res) => {
         if (error) {
                 return res.status(400).json({ status: 0, error });
         }
-        let { recipient, amount, script } = value;
+        let { recipient, amount, script, sender } = value;
         recipient = recipient.trim();
         if(recipient.startsWith('0x') || recipient.startsWith('0X')){
                 recipient = recipient.slice(2);
@@ -22,12 +23,18 @@ export default (req, res) => {
                 return res.status(400).json({ error: 'Invalid recipient address' });
         }
 
-        if(!currentWallet){
+        let wallet = currentWallet;
+        if(sender){
+                const w = wallets.find(wl => wl.publicKey === sender.trim());
+                if(w) wallet = w;
+        }
+
+        if(!wallet){
                 return res.status(400).json({ error: 'No hay una wallet activa' });
         }
 
         try{
-                const tr = currentWallet.createTransaction(recipient, amount, script);
+                const tr = wallet.createTransaction(recipient, amount, script);
                 p2pAction.broadcast(MESSAGE.TR, tr);
                 res.json(tr);
         }catch(error){


### PR DESCRIPTION
## Summary
- allow selecting the sender wallet when creating transactions
- send sender address from frontend forms

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868d36472e4832987134547fa65f1b9