### PR TITLE
Persist active wallet

### DIFF
--- a/src/middleware/Api/Endpoints/wallet_import.js
+++ b/src/middleware/Api/Endpoints/wallet_import.js
@@ -1,5 +1,7 @@
 import Wallet from '../../../wallet/index.js';
-import context, { blockchain, wallets } from '../../../service/context.js';
+import context, { blockchain, wallets, CURRENT_WALLET_FILE } from '../../../service/context.js';
+import { writeFileSync, mkdirSync } from 'fs';
+import path from 'path';
 import Joi from '../../../utils/validator.js';
 
 const schema = Joi.object({
@@ -28,6 +30,13 @@ export default (req, res) => {
         }
         wallets.push(wallet);
         context.currentWallet = wallet;
+        try {
+            const dir = path.dirname(CURRENT_WALLET_FILE);
+            mkdirSync(dir, { recursive: true });
+            writeFileSync(CURRENT_WALLET_FILE, JSON.stringify({ privateKey: wallet.exportPrivateKey() }));
+        } catch {
+            /* ignore persistence errors */
+        }
         res.json({ status: 'ok', data: wallet.blockchainWallet() });
     } catch (err) {
         res.json({ status: 0, error: 'Invalid wallet data' });

--- a/src/middleware/Api/Endpoints/wallet_new.js
+++ b/src/middleware/Api/Endpoints/wallet_new.js
@@ -1,6 +1,8 @@
 import Wallet, { Transaction, blockchainWallet } from '../../../wallet/index.js';
 import { INIT_BL } from '../../../wallet/wallet.js';
-import context, { blockchain, wallets, walletMiner } from '../../../service/context.js';
+import context, { blockchain, wallets, walletMiner, CURRENT_WALLET_FILE } from '../../../service/context.js';
+import { writeFileSync, mkdirSync } from 'fs';
+import path from 'path';
 import Joi from '../../../utils/validator.js';
 
 const schema = Joi.object({
@@ -26,6 +28,13 @@ export default (req, res) => {
 
         context.currentWallet = wallet;
         wallets.push(wallet);
+        try {
+                const dir = path.dirname(CURRENT_WALLET_FILE);
+                mkdirSync(dir, { recursive: true });
+                writeFileSync(CURRENT_WALLET_FILE, JSON.stringify({ privateKey: wallet.exportPrivateKey() }));
+        } catch {
+                /* ignore persistence errors */
+        }
 
         const data = {
                 publicKey: wallet.publicKey,

--- a/src/service/context.js
+++ b/src/service/context.js
@@ -2,7 +2,7 @@ import Blockchain from '../blockchain/index.js';
 import P2PAction from './p2p.js';
 import Wallet from '../wallet/index.js';
 import Miner from '../miner/index.js';
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -11,6 +11,7 @@ const wallets = [];
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const MINER_KEY_FILE = path.join(__dirname, '../storage/miner.key');
+const CURRENT_WALLET_FILE = path.join(__dirname, '../storage/current_wallet.json');
 
 let walletMiner;
 if (existsSync(MINER_KEY_FILE)) {
@@ -37,6 +38,17 @@ const p2pAction = new P2PAction(blockchain);
 const miner = new Miner(blockchain, p2pAction, walletMiner);
 
 let currentWallet = null;
+if (existsSync(CURRENT_WALLET_FILE)) {
+  try {
+    const data = JSON.parse(readFileSync(CURRENT_WALLET_FILE, 'utf8'));
+    if (data && data.privateKey) {
+      currentWallet = Wallet.fromPrivateKey(blockchain, data.privateKey, 0);
+      wallets.push(currentWallet);
+    }
+  } catch {
+    currentWallet = null;
+  }
+}
 
 const context = {
   blockchain,
@@ -52,5 +64,5 @@ const context = {
   }
 };
 
-export { blockchain, wallets, walletMiner, p2pAction, miner, currentWallet };
+export { blockchain, wallets, walletMiner, p2pAction, miner, currentWallet, CURRENT_WALLET_FILE };
 export default context;


### PR DESCRIPTION
## Summary
- persist current wallet to `src/storage/current_wallet.json`
- load saved wallet on startup

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868eccb21dc8329a798885a3979f397