### PR TITLE
Implement WASM execution limits

### DIFF
--- a/__tests__/script_engine.test.js
+++ b/__tests__/script_engine.test.js
@@ -36,4 +36,13 @@ describe('Transaction script validation', () => {
         bc.addBlock([tx], wallet);
         expect(bc.verifyChain()).toBe(false);
     });
+
+    test('infinite wasm script times out and invalidates chain', () => {
+        const infinite = 'AGFzbQEAAAABBQFgAAF/AwIBAAcIAQRtYWluAAAKCwEJAANADAALQQEL';
+        const bc = new Blockchain();
+        const wallet = new Wallet(bc, 50);
+        const tx = Transaction.create(wallet, 'receiver', 10, { type: 'wasm', code: infinite });
+        bc.addBlock([tx], wallet);
+        expect(bc.verifyChain()).toBe(false);
+    });
 });

--- a/src/modules/wasmEngine.js
+++ b/src/modules/wasmEngine.js
@@ -1,13 +1,28 @@
-export default function runWasm(base64Code, context = {}) {
-    try {
-        const wasmBuffer = Buffer.from(base64Code, 'base64');
-        const module = new WebAssembly.Module(wasmBuffer);
-        const instance = new WebAssembly.Instance(module, { env: context });
-        const main = instance.exports.main;
-        if (typeof main !== 'function') return false;
-        return main() === 1;
-    } catch (err) {
-        console.error('WASM execution failed:', err);
-        return false;
-    }
+import { Worker } from 'worker_threads';
+
+// Synchronous execution of potentially untrusted WASM code. The module is run
+// inside a worker so that it can be terminated if it takes too long. A shared
+// buffer is used to communicate the result back to this thread.
+export default function runWasm(base64Code, context = {}, timeout = 100) {
+    const shared = new SharedArrayBuffer(8); // [status, result]
+    const view = new Int32Array(shared);
+
+    const worker = new Worker(new URL('./wasmWorker.js', import.meta.url), {
+        workerData: { code: base64Code, context, shared }
+    });
+
+    const timer = setTimeout(() => {
+        // 1 indicates the execution timed out
+        Atomics.store(view, 0, 1);
+        worker.terminate();
+        Atomics.notify(view, 0);
+    }, timeout);
+
+    // Wait until the worker finishes or timeout triggers
+    Atomics.wait(view, 0, 0);
+    clearTimeout(timer);
+
+    const status = Atomics.load(view, 0);
+    const result = Atomics.load(view, 1);
+    return status === 2 && result === 1;
 }

--- a/src/modules/wasmWorker.js
+++ b/src/modules/wasmWorker.js
@@ -1,0 +1,22 @@
+import { parentPort, workerData } from 'worker_threads';
+
+const { code, context, shared } = workerData;
+const view = new Int32Array(shared);
+
+try {
+  const wasmBuffer = Buffer.from(code, 'base64');
+  const module = new WebAssembly.Module(wasmBuffer);
+  // restrict memory to one page if module expects it via import
+  const memory = new WebAssembly.Memory({ initial: 1, maximum: 1 });
+  const instance = new WebAssembly.Instance(module, { env: { ...context, memory } });
+  const main = instance.exports.main;
+  let ok = false;
+  if (typeof main === 'function') {
+    ok = main() === 1;
+  }
+  view[1] = ok ? 1 : 0; // result index
+} catch (err) {
+  view[1] = 0;
+}
+view[0] = 2; // done
+Atomics.notify(view, 0);


### PR DESCRIPTION
## Summary
- add worker-based WASM runner with timeout and small memory
- use the new worker in `runWasm`
- test that infinite WASM scripts do not hang the blockchain

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868f13a5e1083299854b182d59680e5