### PR TITLE
Add metadata support for transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ use this, include an object `{ type: 'wasm', code: '<base64>' }` in the
 `main` function that returns `1` on success. These modules run in a minimal
 environment, providing the transaction data through the `env` import object.
 
+### Transaction Metadata
+
+Each transaction may optionally include arbitrary metadata. This data is stored
+in the new `metadata` field and is signed along with the rest of the
+transaction contents. Use the CLI `send` command with `--metadata` or the web
+form to attach JSON data to a transfer. Metadata is verified when signatures are
+checked so it cannot be tampered with after the fact.
+
 ### API Endpoints
 
 The REST API exposes several helpers for querying the chain:

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -85,12 +85,22 @@ program
 program
   .command('send <recipient> <amount>')
   .option('-s, --script <script>')
+  .option('-m, --metadata <json>', 'Optional metadata as JSON')
   .description('Send transaction')
   .action((recipient, amount, opts) => {
+    let metadata;
+    if (opts.metadata) {
+      try {
+        metadata = JSON.parse(opts.metadata);
+      } catch {
+        metadata = opts.metadata;
+      }
+    }
     runEndpoint(transactionsNew, {
       recipient,
       amount: Number(amount),
       script: opts.script,
+      metadata,
     });
   });
 

--- a/pages/send.tsx
+++ b/pages/send.tsx
@@ -13,16 +13,21 @@ export default function Send() {
   const [amount, setAmount] = useState('')
   const [message, setMessage] = useState<string | null>(null)
   const [sending, setSending] = useState(false)
+  const [metadata, setMetadata] = useState('')
 
   async function handleSend() {
     if (!wallet || sending) return
     setSending(true)
     setMessage(null)
     try {
+      let meta
+      if (metadata) {
+        try { meta = JSON.parse(metadata) } catch { meta = metadata }
+      }
       const res = await fetch(`${API_BASE}/api/transactions`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ recipient, amount: parseFloat(amount), sender: wallet.publicKey })
+        body: JSON.stringify({ recipient, amount: parseFloat(amount), sender: wallet.publicKey, metadata: meta })
       })
       const data = await res.json()
       await refreshBalance()
@@ -57,6 +62,11 @@ export default function Send() {
             type="number"
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
+          />
+          <Input
+            placeholder="Metadata (JSON optional)"
+            value={metadata}
+            onChange={(e) => setMetadata(e.target.value)}
           />
           <Button onClick={handleSend} disabled={sending}>
             {sending ? 'Sending...' : 'Send'}

--- a/src/middleware/Api/Endpoints/transactions_new.js
+++ b/src/middleware/Api/Endpoints/transactions_new.js
@@ -6,6 +6,7 @@ const schema = Joi.object({
     recipient: Joi.string().required(),
     amount: Joi.number().positive().required(),
     script: Joi.string().allow('', null),
+    metadata: Joi.any(),
     sender: Joi.string().allow('', null)
 });
 
@@ -14,7 +15,7 @@ export default (req, res) => {
         if (error) {
                 return res.status(400).json({ status: 0, error });
         }
-        let { recipient, amount, script, sender } = value;
+        let { recipient, amount, script, metadata, sender } = value;
         recipient = recipient.trim();
         if(recipient.startsWith('0x') || recipient.startsWith('0X')){
                 recipient = recipient.slice(2);
@@ -34,7 +35,7 @@ export default (req, res) => {
         }
 
         try{
-                const tr = wallet.createTransaction(recipient, amount, script);
+                const tr = wallet.createTransaction(recipient, amount, script, { type: 'COIN', id: null }, metadata);
                 p2pAction.broadcast(MESSAGE.TR, tr);
                 res.json(tr);
         }catch(error){

--- a/src/wallet/wallet.js
+++ b/src/wallet/wallet.js
@@ -108,7 +108,7 @@ class Wallet{
         }
 
 
-        createTransaction(receptAddress, amount, script = null, asset = { type: 'COIN', id: null }){
+        createTransaction(receptAddress, amount, script = null, asset = { type: 'COIN', id: null }, metadata = null){
                 const { blockchain: { memoryPool } } = this;
 
                 const isCoin = asset.type === 'COIN';
@@ -127,9 +127,9 @@ class Wallet{
 
                 let tr = memoryPool.find(this.publicKey);
                 if(isCoin && tr && tr.asset.type === 'COIN'){
-                        tr.update(this, receptAddress, amt, script);
+                        tr.update(this, receptAddress, amt, script, metadata);
                 } else {
-                        tr = Transaction.create(this, receptAddress, amt, script, asset);
+                        tr = Transaction.create(this, receptAddress, amt, script, asset, metadata);
                         memoryPool.addOrUpdate(tr);
                 }
 


### PR DESCRIPTION
## Summary
- extend `Transaction` with optional `metadata` field
- include metadata in signing and verification
- allow `Wallet.createTransaction` and `Transaction.update` to handle metadata
- expose metadata through API endpoint and CLI
- update web interface to send metadata
- document feature in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868f223ab5083299ebf7c0117ae588d
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for optional metadata in transactions, allowing users to attach and sign extra data with each transfer.

- **New Features**
  - Transactions now include a `metadata` field that is signed and verified.
  - Metadata can be added via the CLI, API, and web interface.
  - Updated documentation to explain how to use transaction metadata.

<!-- End of auto-generated description by cubic. -->

