### PR TITLE
Add modern Network Analytics page

### DIFF
--- a/components/analytics/AnalyticsCard.tsx
+++ b/components/analytics/AnalyticsCard.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from 'react'
+import MiniChart from './MiniChart'
+import StatBlock from './StatBlock'
+
+interface AnalyticsCardProps {
+  title: string
+  value: ReactNode
+  icon?: ReactNode
+  data?: number[]
+  color?: string
+}
+
+export default function AnalyticsCard({
+  title,
+  value,
+  icon,
+  data = [],
+  color = '#3b82f6',
+}: AnalyticsCardProps) {
+  return (
+    <div className="bg-neutral-900 rounded-xl p-4 hover:shadow-md hover:shadow-white/10 transition space-y-2">
+      <StatBlock title={title} value={value} icon={icon} />
+      {data.length > 0 && <MiniChart data={data} color={color} />}
+    </div>
+  )
+}

--- a/components/analytics/MiniChart.tsx
+++ b/components/analytics/MiniChart.tsx
@@ -1,0 +1,27 @@
+interface MiniChartProps {
+  data: number[]
+  color: string
+}
+
+export default function MiniChart({ data, color }: MiniChartProps) {
+  if (!data.length) return <svg className="w-full h-20" />
+  const max = Math.max(...data, 1)
+  const points = data
+    .map((v, i) => {
+      const x = (i / (data.length - 1)) * 100
+      const y = 100 - (v / max) * 100
+      return `${x},${y}`
+    })
+    .join(' ')
+
+  return (
+    <svg viewBox="0 0 100 100" className="w-full h-20">
+      <polyline
+        fill="none"
+        stroke={color}
+        strokeWidth="2"
+        points={points}
+      />
+    </svg>
+  )
+}

--- a/components/analytics/StatBlock.tsx
+++ b/components/analytics/StatBlock.tsx
@@ -1,0 +1,30 @@
+import { ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+interface StatBlockProps {
+  title: string
+  value: ReactNode
+  icon?: ReactNode
+}
+
+export default function StatBlock({ title, value, icon }: StatBlockProps) {
+  return (
+    <div
+      className="bg-neutral-900 rounded-xl p-4 flex items-center space-x-3 hover:shadow-md hover:shadow-white/10 transition"
+    >
+      {icon && (
+        <span className="text-xl" aria-label={title}>
+          {icon}
+        </span>
+      )}
+      <div>
+        <div className="text-neutral-400 uppercase text-xs tracking-wide">
+          {title}
+        </div>
+        <div className="text-white text-xl font-semibold text-balance">
+          {value}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/analytics/index.ts
+++ b/components/analytics/index.ts
@@ -1,0 +1,3 @@
+export { default as AnalyticsCard } from './AnalyticsCard'
+export { default as MiniChart } from './MiniChart'
+export { default as StatBlock } from './StatBlock'

--- a/pages/NetworkAnalytics.tsx
+++ b/pages/NetworkAnalytics.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react'
+import AnalyticsCard from '@/components/analytics/AnalyticsCard'
+import MiniChart from '@/components/analytics/MiniChart'
+
+const API_BASE = 'http://localhost:8000'
+const WS_BASE = 'ws://localhost:8000'
+
+const ranges = ['Last 10 blocks', 'Last hour', 'All time']
+
+function formatTime(ms: number) {
+  const sec = ms / 1000
+  const h = Math.floor(sec / 3600)
+  const m = Math.floor((sec % 3600) / 60)
+  const s = Math.floor(sec % 60)
+  return [h, m, s].map((n) => String(n).padStart(2, '0')).join(':')
+}
+
+export default function NetworkAnalytics() {
+  const [stats, setStats] = useState<any>(null)
+  const [blockTimes, setBlockTimes] = useState<number[]>([])
+  const [mempoolSizes, setMempoolSizes] = useState<number[]>([])
+  const [nodes, setNodes] = useState<number[]>([])
+  const [heights, setHeights] = useState<number[]>([])
+  const [range, setRange] = useState(ranges[0])
+
+  useEffect(() => {
+    const ws = new WebSocket(`${WS_BASE}/api/metrics/live`)
+    ws.onmessage = (ev) => {
+      const data = JSON.parse(ev.data)
+      setBlockTimes((b) => [...b.slice(-19), data.blockTime])
+      setMempoolSizes((m) => [...m.slice(-19), data.mempoolSize])
+      setNodes((n) => [...n.slice(-19), data.connectedNodes])
+      setHeights((h) => [...h.slice(-29), data.blockHeight])
+    }
+    return () => ws.close()
+  }, [])
+
+  useEffect(() => {
+    const load = () => {
+      fetch(`${API_BASE}/api/metrics/extended`)
+        .then((r) => r.json())
+        .then(setStats)
+        .catch(console.error)
+    }
+    load()
+    const id = setInterval(load, 5000)
+    return () => clearInterval(id)
+  }, [])
+
+  return (
+    <div className="bg-neutral-950 min-h-screen py-10 px-6">
+      <div className="max-w-6xl mx-auto space-y-8">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-semibold text-white">Network Analytics</h1>
+          <select
+            className="bg-neutral-900 text-white rounded px-3 py-2"
+            value={range}
+            onChange={(e) => setRange(e.target.value)}
+          >
+            {ranges.map((r) => (
+              <option key={r}>{r}</option>
+            ))}
+          </select>
+        </div>
+        {stats && (
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
+            <AnalyticsCard
+              title="Block Height"
+              value={stats.chainLength.toLocaleString()}
+              icon="⛓"
+              data={heights}
+              color="#e879f9"
+            />
+            <AnalyticsCard
+              title="Total Stake"
+              value={stats.totalStake.toLocaleString()}
+              icon="💰"
+            />
+            <AnalyticsCard
+              title="Total Transactions"
+              value={stats.totalTransactions.toLocaleString()}
+              icon="🔄"
+            />
+            <AnalyticsCard
+              title="Mempool Size"
+              value={stats.mempoolSize.toLocaleString()}
+              icon="📥"
+              data={mempoolSizes}
+              color="#f97316"
+            />
+            <AnalyticsCard
+              title="Average Block Time"
+              value={formatTime(stats.avgBlockTime)}
+              icon="⏱"
+              data={blockTimes}
+              color="#3b82f6"
+            />
+            <AnalyticsCard
+              title="Unique Addresses"
+              value={stats.uniqueAddresses.toLocaleString()}
+              icon="🏷"
+            />
+            <AnalyticsCard
+              title="Connected Nodes"
+              value={stats.connectedNodes.toLocaleString()}
+              icon="🌐"
+              data={nodes}
+              color="#22c55e"
+            />
+            {stats.syncStatus && (
+              <AnalyticsCard
+                title="Sync Status"
+                value={stats.syncStatus}
+                icon="🔄"
+              />
+            )}
+          </div>
+        )}
+        <div className="bg-neutral-900 rounded-xl p-4">
+          <h2 className="text-neutral-400 uppercase text-sm tracking-wide mb-2">
+            Live Block Height
+          </h2>
+          <MiniChart data={heights} color="#e879f9" />
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- build reusable analytics UI components
- implement NetworkAnalytics page with dark theme, charts, and stat blocks

## Testing
- `npx jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_b_6868f35279e883299a2d4e4dc9cf59ec
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a modern Network Analytics page with live charts, stat blocks, and a dark theme using reusable React components.

- **New Features**
  - Built AnalyticsCard, MiniChart, and StatBlock components for displaying stats and charts.
  - Implemented real-time updates for network metrics like block height, mempool size, and connected nodes.

<!-- End of auto-generated description by cubic. -->

