### PR TITLE
Fix Joi.any error by adding any validator

### DIFF
--- a/src/utils/validator.js
+++ b/src/utils/validator.js
@@ -53,4 +53,12 @@ function object(schema) {
   };
 }
 
-export default { string, number, object };
+function any() {
+  return {
+    validate(value) {
+      return { value };
+    }
+  };
+}
+
+export default { string, number, object, any };


### PR DESCRIPTION
## Summary
- implement a simple `any` validator in `src/utils/validator.js`
- allow `transactions_new.js` to use `Joi.any()`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868f40c22ac83298eec182419f9bb63
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a simple any validator to support Joi.any() in the custom validator utility.

<!-- End of auto-generated description by cubic. -->

