### PR TITLE
Fix connected node count on analytics page

### DIFF
--- a/pages/analytics.tsx
+++ b/pages/analytics.tsx
@@ -102,7 +102,7 @@ export default function Analytics() {
             />
             <AnalyticsCard
               title="Connected Nodes"
-              value={stats.connectedNodes.toLocaleString()}
+              value={(stats.connectedNodes ?? nodes[nodes.length - 1] ?? 0).toLocaleString()}
               icon="🌐"
               data={nodes}
               color="#22c55e"


### PR DESCRIPTION
## Summary
- handle undefined `connectedNodes` in analytics page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868f5e5a1788329a82893b4c3779920
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug where the connected node count on the analytics page could show as undefined by adding a fallback value.

<!-- End of auto-generated description by cubic. -->

