### PR TITLE
Fix send address validation

### DIFF
--- a/pages/send.tsx
+++ b/pages/send.tsx
@@ -9,6 +9,8 @@ import { Tooltip } from 'react-tooltip'
 import 'react-tooltip/dist/react-tooltip.css'
 import { cn } from '@/lib/utils'
 
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000'
+
 const GAS_OPTIONS = [
   { label: 'Slow', value: 15 },
   { label: 'Standard', value: 25 },
@@ -49,7 +51,8 @@ export default function Send() {
     }
   }, [toast])
 
-  const validAddress = /^0x[a-fA-F0-9]{40}$/.test(to)
+  const cleaned = to.startsWith('0x') ? to.slice(2) : to
+  const validAddress = /^[a-fA-F0-9]+$/.test(cleaned)
   const amt = parseFloat(amount)
   const validAmount = !isNaN(amt) && amt > 0
   const valid = validAddress && validAmount && from && !loading


### PR DESCRIPTION
## Summary
- add missing `API_BASE` constant
- relax address validation in `send.tsx`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run eslint` *(fails: ESLint configuration missing)*

------
https://chatgpt.com/codex/tasks/task_b_6868f954260883299a28f72cfdc66704
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed address validation in the send page to accept a wider range of input formats and added the missing API_BASE constant.

<!-- End of auto-generated description by cubic. -->

