### PR TITLE
Añadir pruebas unitarias de minero y métricas

### DIFF
--- a/__tests__/metrics_endpoints.test.js
+++ b/__tests__/metrics_endpoints.test.js
@@ -1,0 +1,49 @@
+jest.mock('../src/service/context.js', () => ({
+  __esModule: true,
+  blockchain: { getExtendedStats: jest.fn() },
+  p2pAction: { sockets: [] }
+}));
+
+import metricsExtended from '../src/middleware/Api/Endpoints/metrics_extended.js';
+import metricsPrometheus from '../src/middleware/Api/Endpoints/metrics_prometheus.js';
+import { blockchain, p2pAction } from '../src/service/context.js';
+
+beforeEach(() => {
+  blockchain.getExtendedStats.mockReset();
+  p2pAction.sockets = [];
+});
+
+describe('Metrics API endpoints', () => {
+  test('metrics_extended returns stats as json', () => {
+    const stats = { chainLength: 2 };
+    blockchain.getExtendedStats.mockReturnValue(stats);
+    const res = { json: jest.fn() };
+    metricsExtended({}, res);
+    expect(blockchain.getExtendedStats).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(stats);
+  });
+
+  test('metrics_prometheus returns formatted metrics', () => {
+    const stats = {
+      chainLength: 5,
+      totalTransactions: 7,
+      totalStake: 3,
+      avgBlockTime: 10,
+      mempoolSize: 0,
+      uniqueAddresses: 4
+    };
+    blockchain.getExtendedStats.mockReturnValue(stats);
+    p2pAction.sockets = [1, 2, 3];
+    const res = { set: jest.fn(), send: jest.fn() };
+    metricsPrometheus({}, res);
+    expect(res.set).toHaveBeenCalledWith('Content-Type', 'text/plain');
+    const sent = res.send.mock.calls[0][0];
+    expect(sent).toContain(`bydchain_block_height ${stats.chainLength}`);
+    expect(sent).toContain(`bydchain_total_transactions ${stats.totalTransactions}`);
+    expect(sent).toContain(`bydchain_total_stake ${stats.totalStake}`);
+    expect(sent).toContain(`bydchain_avg_block_time ${stats.avgBlockTime}`);
+    expect(sent).toContain(`bydchain_mempool_size ${stats.mempoolSize}`);
+    expect(sent).toContain(`bydchain_connected_nodes ${p2pAction.sockets.length}`);
+    expect(sent).toContain(`bydchain_unique_addresses ${stats.uniqueAddresses}`);
+  });
+});

--- a/__tests__/miner.test.js
+++ b/__tests__/miner.test.js
@@ -1,0 +1,50 @@
+jest.mock('../src/wallet/index.js', () => ({
+  __esModule: true,
+  Transaction: { reward: jest.fn() },
+  blockchainWallet: 'chainWallet'
+}));
+
+import Miner from '../src/miner/miner.js';
+import { Transaction, blockchainWallet } from '../src/wallet/index.js';
+import { MESSAGE } from '../src/service/p2p.js';
+
+beforeEach(() => {
+  Transaction.reward.mockReset();
+});
+
+describe('Miner.mine', () => {
+  test('throws when mempool empty', () => {
+    const bc = { memoryPool: { transactions: [] } };
+    const p2p = {};
+    const wallet = {};
+    const miner = new Miner(bc, p2p, wallet);
+    expect(() => miner.mine()).toThrow('La transacción no esta confirmada');
+  });
+
+  test('mines block and clears mempool', () => {
+    const rewardTx = { id: 'reward' };
+    Transaction.reward.mockReturnValue(rewardTx);
+    const mempool = {
+      transactions: [{ id: 'tx1' }],
+      wipe: jest.fn(function () { this.transactions = []; })
+    };
+    const block = { index: 1 };
+    const bc = {
+      memoryPool: mempool,
+      addBlock: jest.fn(() => block)
+    };
+    const p2p = { sync: jest.fn(), broadcast: jest.fn() };
+    const wallet = { pk: 'miner' };
+    const miner = new Miner(bc, p2p, wallet);
+
+    const result = miner.mine();
+
+    expect(Transaction.reward).toHaveBeenCalledWith(wallet, blockchainWallet);
+    expect(bc.addBlock).toHaveBeenCalledWith([{ id: 'tx1' }, rewardTx], wallet);
+    expect(p2p.sync).toHaveBeenCalled();
+    expect(mempool.wipe).toHaveBeenCalled();
+    expect(p2p.broadcast).toHaveBeenCalledWith(MESSAGE.WIPE);
+    expect(result).toBe(block);
+    expect(mempool.transactions).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Resumen
- agregar test para la función `mine` del minero
- probar los endpoints de métricas extendidas y en formato Prometheus

## Resultados de las pruebas
- `npm test` falló porque `jest` no está instalado
- `npm run eslint` falló por falta de configuración y dependencias

------
https://chatgpt.com/codex/tasks/task_b_6868fd6544848329995cfa48cd1a9965