### PR TITLE
Fix SSR issue in VM Playground

### DIFF
--- a/pages/vm-playground.tsx
+++ b/pages/vm-playground.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import dynamic from 'next/dynamic'
 import Ajv from 'ajv'
-import ReactJson from 'react-json-view'
+const ReactJson = dynamic(() => import('react-json-view'), { ssr: false })
 import { Button } from '@/components/ui/button'
 import { useTheme } from '@/components/ThemeContext'
 


### PR DESCRIPTION
## Summary
- fix SSR crash on vm-playground by importing ReactJson dynamically

## Testing
- `npm test` *(fails: jest not found)*
- `npm run eslint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_b_686906835cb0832991eb138355a1a9d2
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a server-side rendering crash in the VM Playground by loading ReactJson only on the client.

<!-- End of auto-generated description by cubic. -->

